### PR TITLE
Wb1.1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Unten sehen Sie eine vereinfachte Darstellung wie unser Dungeon jetzt funktionie
 
 ## Head-up-Display (HUD)
 
-Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung. Alternativ können Sie ab Version `1.1.5.0` mithilfe von `hud.usePixelSystem(true)` im `MainCotroller` auf ein Pixelbasiertes HUD wechseln. 
+Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung. Alternativ können Sie ab Version `1.1.5.0` mithilfe von `hud.usePixelSystem(true)` im `MainCotroller` auf ein pixelbasiertes HUD wechseln. 
 
 Um eine Grafik auf dem HUD anzeigen zu können, erstellen wir zuerst eine neue Klasse, welche das Interface `IHUDElement` implementiert.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Unten sehen Sie eine vereinfachte Darstellung wie unser Dungeon jetzt funktionie
 
 ## Head-up-Display (HUD)
 
-Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung.
+Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung. Alternativ können Sie ab Version `1.1.5.0` mithilfe von `hud.usePixelSystem(true)` im `MainCotroller` auf ein Pixelbasiertes HUD wechseln. 
 
 Um eine Grafik auf dem HUD anzeigen zu können, erstellen wir zuerst eine neue Klasse, welche das Interface `IHUDElement` implementiert.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 ---
 title: "Dokumentation zum PM-Dungeon"
 author: "André Matutat"
-lang: de-DE
-...
-
-
+lang: de-DE ...
 
 ## Einleitung
 
-Dieses Dokument liefert einen Einstieg in das PM-Dungeon. Es erläutert die Installation der API und erläutert Ihnen die ersten Schritte, um eigene Inhalte zum Dungeon hinzuzufügen. Es dient als Grundlage für alle weiteren Praktika. Lesen Sie das Dokument daher aufmerksam durch und versuchen Sie sich zusätzlich selbst mit dem Aufbau vertraut zu machen.
+Dieses Dokument liefert einen Einstieg in das PM-Dungeon. Es erläutert die Installation der API und erläutert Ihnen die
+ersten Schritte, um eigene Inhalte zum Dungeon hinzuzufügen. Es dient als Grundlage für alle weiteren Praktika. Lesen
+Sie das Dokument daher aufmerksam durch und versuchen Sie sich zusätzlich selbst mit dem Aufbau vertraut zu machen.
 
 ## Installation
 
-- Laden Sie sich das `pmdungeon.jar` und den `assets`-Ordner mit Texturen und Level-Beschreibungen herunter. Das `pmdungeon.jar` wird Ihnen als API dienen.
+- Laden Sie sich das `pmdungeon.jar` und den `assets`-Ordner mit Texturen und Level-Beschreibungen herunter.
+  Das `pmdungeon.jar` wird Ihnen als API dienen.
 - Erstellen Sie in Ihrer IDE ein neues Java-Projekt
 - Integrieren Sie die `pmdungeon.jar` als Library in Ihrem Projekt
 - Kopieren Sie den `assets`-Ordner in Ihr Projektverzeichnis
@@ -21,13 +21,27 @@ Dieses Dokument liefert einen Einstieg in das PM-Dungeon. Es erläutert die Inst
 
 Zu Beginn einige grundlegende Prinzipien, die Sie verstanden haben sollten, bevor Sie mit dem Dungeon arbeiten.
 
-- Das PM-Dungeon wird mithilfe des Cross-Plattform Java-Frameworks [`libGDX`](https://libgdx.com) umgesetzt. Dieses ist in der `pmdungeon.jar` bereits integriert, Sie müssen dieses nicht extra installieren. Die Ihnen zur Verfügung gestellten Vorgaben sind so umgesetzt, dass Sie kein tieferes Verständnis für das Framework benötigen, um die Aufgaben zu lösen. Sollten Sie allerdings einmal auf Probleme stoßen, kann es unter Umständen helfen, einen Blick in die Dokumentation von `libGDX` zu werfen.
-- Die API enthält bereits einige vordefinierte Spiel-Level (Ebenen im Dungeon). Sie müssen sich daher nicht mit der Generierung von Dungeons auseinandersetzen. Level werden als 2D-Array gespeichert, wobei jedes Feld entweder ein Boden, eine Wand oder `null` sein kann.
-- Zwar wird das Level als 2D-Array gespeichert und daher sind Koordinaten auch als Integer-Tupel bestimmbar, allerdings verwendet die API intern virtuelle Einheiten. (Welche Vorteile dieses Vorgehen liefert können Sie [hier](https://xoppa.github.io/blog/pixels/) nachlesen). Daher lassen sich Entitäten auch zwischen den Feldern zeichnen.
+- Das PM-Dungeon wird mithilfe des Cross-Plattform Java-Frameworks [`libGDX`](https://libgdx.com) umgesetzt. Dieses ist
+  in der `pmdungeon.jar` bereits integriert, Sie müssen dieses nicht extra installieren. Die Ihnen zur Verfügung
+  gestellten Vorgaben sind so umgesetzt, dass Sie kein tieferes Verständnis für das Framework benötigen, um die Aufgaben
+  zu lösen. Sollten Sie allerdings einmal auf Probleme stoßen, kann es unter Umständen helfen, einen Blick in die
+  Dokumentation von `libGDX` zu werfen.
+- Die API enthält bereits einige vordefinierte Spiel-Level (Ebenen im Dungeon). Sie müssen sich daher nicht mit der
+  Generierung von Dungeons auseinandersetzen. Level werden als 2D-Array gespeichert, wobei jedes Feld entweder ein
+  Boden, eine Wand oder `null` sein kann.
+- Zwar wird das Level als 2D-Array gespeichert und daher sind Koordinaten auch als Integer-Tupel bestimmbar, allerdings
+  verwendet die API intern virtuelle Einheiten. (Welche Vorteile dieses Vorgehen liefert können
+  Sie [hier](https://xoppa.github.io/blog/pixels/) nachlesen). Daher lassen sich Entitäten auch zwischen den Feldern
+  zeichnen.
 
 ![Positionen am Beispiel der X-Position](./img/x+1.png)
 
-- Game-Loop: Die Game-Loop ist die wichtigste Komponente des Spieles. Sie ist eine Endlosschleife, welche einmal pro [Frame](https://de.wikipedia.org/wiki/Bildfrequenz) aufgerufen wird. Das Spiel läuft in 30-FPS (also 30 *frames per seconds*, zu Deutsch 30 Bildern pro Sekunde), die Game-Loop wird also 30mal in der Sekunde aufgerufen. Alle Aktionen, die wiederholt ausgeführt werden müssen, wie zum Beispiel das Bewegen und Zeichnen von Figuren, müssen innerhalb der Game-Loop stattfinden. Die API ermöglicht es Ihnen, eigene Aktionen in die Game-Loop zu integrieren. Wie genau das geht, erfahren Sie im Laufe dieser Dokumentation.
+- Game-Loop: Die Game-Loop ist die wichtigste Komponente des Spieles. Sie ist eine Endlosschleife, welche einmal
+  pro [Frame](https://de.wikipedia.org/wiki/Bildfrequenz) aufgerufen wird. Das Spiel läuft in 30-FPS (also 30 *frames
+  per seconds*, zu Deutsch 30 Bildern pro Sekunde), die Game-Loop wird also 30mal in der Sekunde aufgerufen. Alle
+  Aktionen, die wiederholt ausgeführt werden müssen, wie zum Beispiel das Bewegen und Zeichnen von Figuren, müssen
+  innerhalb der Game-Loop stattfinden. Die API ermöglicht es Ihnen, eigene Aktionen in die Game-Loop zu integrieren. Wie
+  genau das geht, erfahren Sie im Laufe dieser Dokumentation.
 
   *Hinweis: Die Game-Loop wird automatisch ausgeführt, Sie müssen sie nicht aktiv aufrufen.*
 
@@ -41,10 +55,10 @@ In diesen Abschnitt werden alle Schritte erläutert, die zum ersten Start der An
 
 - Überschreiben Sie alle notwendigen Methoden:
 
-  - `protected void setup()`
-  - `protected void beginFrame()`
-  - `protected void endFrame()`
-  - `public void onLevelLoad()`
+    - `protected void setup()`
+    - `protected void beginFrame()`
+    - `protected void endFrame()`
+    - `public void onLevelLoad()`
 
   *Hinweis: Weitere Informationen zu diesen Methoden erfolgen im Laufe der Dokumentation.*
 
@@ -57,15 +71,25 @@ In diesen Abschnitt werden alle Schritte erläutert, die zum ersten Start der An
     }
     ```
 
-Das Spiel sollte nun starten und Sie sollten ein schwarzes Fenster mit einem Teil des Dungeons in der oberen rechten Ecke sehen.
+Das Spiel sollte nun starten und Sie sollten ein schwarzes Fenster mit einem Teil des Dungeons in der oberen rechten
+Ecke sehen.
 
-Bevor wir nun unseren Helden implementieren sollten wir verstehen, was genau der `MainController` eigentlich ist. Wie der Name schon vermuten lässt, ist dies die Haupt-Steuerung des Spiels. Er bereitet alles für den Start des Spieles vor, verwaltet die anderen Controller und enthält die Game-Loop. Wir nutzen unsere Klasse, welche vom `MainController` erbt, um selbst in die Game-Loop einzugreifen und unsere eigenen Objekte wie Helden und Monster zu verwalten. Der `MainController` ist der Punkt, an dem alle Fäden des Dungeons zusammenlaufen. Im Folgenden wird Ihnen erklärt, wie Sie erfolgreich mit dem `MainController` arbeiten.
+Bevor wir nun unseren Helden implementieren sollten wir verstehen, was genau der `MainController` eigentlich ist. Wie
+der Name schon vermuten lässt, ist dies die Haupt-Steuerung des Spiels. Er bereitet alles für den Start des Spieles vor,
+verwaltet die anderen Controller und enthält die Game-Loop. Wir nutzen unsere Klasse, welche vom `MainController` erbt,
+um selbst in die Game-Loop einzugreifen und unsere eigenen Objekte wie Helden und Monster zu verwalten.
+Der `MainController` ist der Punkt, an dem alle Fäden des Dungeons zusammenlaufen. Im Folgenden wird Ihnen erklärt, wie
+Sie erfolgreich mit dem `MainController` arbeiten.
 
 ## Eigener Held
 
-Jetzt, wo Sie sichergestellt haben, dass das Dungeon ausgeführt werden kann, geht es darum, das Spiel mit Ihren Inhalten zu erweitern. Im Folgenden wird ein rudimentärer Held implementiert, um Ihnen die verschiedenen Aspekte des Dungeon zu erläutern.
+Jetzt, wo Sie sichergestellt haben, dass das Dungeon ausgeführt werden kann, geht es darum, das Spiel mit Ihren Inhalten
+zu erweitern. Im Folgenden wird ein rudimentärer Held implementiert, um Ihnen die verschiedenen Aspekte des Dungeon zu
+erläutern.
 
-Fangen wir damit an eine neue Klasse für den Helden anzulegen. Da unser Held eine Animation haben soll, implementieren wir das Interface `IAnimatable`. Dies erlaubt es uns, unseren Helden zu animieren. Für Objekte, die keine Animation haben, sondern nur eine Textur, würden wir das Interface `IDrawable` implementieren.
+Fangen wir damit an eine neue Klasse für den Helden anzulegen. Da unser Held eine Animation haben soll, implementieren
+wir das Interface `IAnimatable`. Dies erlaubt es uns, unseren Helden zu animieren. Für Objekte, die keine Animation
+haben, sondern nur eine Textur, würden wir das Interface `IDrawable` implementieren.
 
 ```java
 public class Hero implements IAnimatable {
@@ -76,37 +100,43 @@ public class Hero implements IAnimatable {
 
 ### Der bewegte (animierte) Held
 
-Fangen wir damit an, die Animation für unseren Helden zu erstellen. Eine Animation ist eine Liste mit verschieden Texturen, die nacheinander abgespielt werden.
+Fangen wir damit an, die Animation für unseren Helden zu erstellen. Eine Animation ist eine Liste mit verschieden
+Texturen, die nacheinander abgespielt werden.
 
 ```java
 //Anlegen einer Animation
 private Animation idleAnimation;
-public Hero() {
-    //Erstellen einer ArrayList
-    List <Texture> idle = new ArrayList<>();
-    //Laden der Texturen für die Animation (Pfad angeben)
-    idle.add(new Texture(PATH_TO_TEXTURE_1.png));
-    idle.add(new Texture(PATH_TO_TEXTURE_1.png));
-    //Erstellen einer Animation, als Parameter wird die Liste mit den Texturen
-    //und die Wartezeit (in Frames) zwischen den Wechsel der Texturen angegeben
-    idleAnimation = new Animation(idle,8);
-}
+public Hero(){
+        //Erstellen einer ArrayList
+        List<Texture> idle=new ArrayList<>();
+        //Laden der Texturen für die Animation (Pfad angeben)
+        idle.add(new Texture(PATH_TO_TEXTURE_1.png));
+        idle.add(new Texture(PATH_TO_TEXTURE_1.png));
+        //Erstellen einer Animation, als Parameter wird die Liste mit den Texturen
+        //und die Wartezeit (in Frames) zwischen den Wechsel der Texturen angegeben
+        idleAnimation=new Animation(idle,8);
+        }
 
 @Override
 //Da unser Held aktuell nur eine Animation hat,
 //geben wir diese als aktuell aktive Animation zurück
-public Animation getActiveAnimation() {
-    return this.idle;
-}
+public Animation getActiveAnimation(){
+        return this.idle;
+        }
 ```
 
 Super, jetzt hat unser Held eine Animation. Nun muss diese noch im Spiel gezeichnet werden.
 
-Da das Dungeon framebasiert ist, muss unser Held in jedem Frame (also 30-mal in der Sekunde) neu gezeichnet werden. Dazu verwenden Wir das `IEntity` Interface, welches uns erlaubt Objekte vom `EntityController` managen zu lassen.
+Da das Dungeon framebasiert ist, muss unser Held in jedem Frame (also 30-mal in der Sekunde) neu gezeichnet werden. Dazu
+verwenden Wir das `IEntity` Interface, welches uns erlaubt Objekte vom `EntityController` managen zu lassen.
 
-Der `EntityController` verwendet das *Observer-Pattern* (vergleiche Vorlesung) um Instanzen vom Typen `IEntity` zu verwalten. Er sorgt dafür, dass die vom Interface bereitgestellte `update`-Methode jeder Entität in der Game-Loop aufgerufen wird. Dazu hält er eine Liste mit allen ihm übergebenen Entitäten. Weiter unten sehen Sie, wie Sie den `EntityController` verwenden können, um unseren Helden managen zu lassen.
+Der `EntityController` verwendet das *Observer-Pattern* (vergleiche Vorlesung) um Instanzen vom Typen `IEntity` zu
+verwalten. Er sorgt dafür, dass die vom Interface bereitgestellte `update`-Methode jeder Entität in der Game-Loop
+aufgerufen wird. Dazu hält er eine Liste mit allen ihm übergebenen Entitäten. Weiter unten sehen Sie, wie Sie
+den `EntityController` verwenden können, um unseren Helden managen zu lassen.
 
-*Hinweis: Der `MainController` verfügt bereits über einen `EntityController`, welchen Sie innerhalb der Klasse mit `entityController` ansprechen können*
+*Hinweis: Der `MainController` verfügt bereits über einen `EntityController`, welchen Sie innerhalb der Klasse
+mit `entityController` ansprechen können*
 
 Dafür implementiert unser Held nun zusätzlich das `IEntity`-Interface und die `update`-Methode.
 
@@ -125,7 +155,10 @@ public class Hero implements IAnimatable, IEntity {
 
 ### Wo bin ich?
 
-Jetzt ist unsere erste Version vom Helden fast fertig, wir benötigen lediglich noch ein paar kleinere Informationen. Zuerst muss unser Held wissen, wo er überhaupt im Dungeon steht, dafür benötigt er eine Position. Zusätzlich wäre es hilfreich, wenn unser Held das Level (die Dungeon-Ebene) kennen würde, da wir so vermeiden können, dass sich unser Held durch Wände bewegt oder sich außerhalb des eigentlichen Spielbereiches aufhält.
+Jetzt ist unsere erste Version vom Helden fast fertig, wir benötigen lediglich noch ein paar kleinere Informationen.
+Zuerst muss unser Held wissen, wo er überhaupt im Dungeon steht, dafür benötigt er eine Position. Zusätzlich wäre es
+hilfreich, wenn unser Held das Level (die Dungeon-Ebene) kennen würde, da wir so vermeiden können, dass sich unser Held
+durch Wände bewegt oder sich außerhalb des eigentlichen Spielbereiches aufhält.
 
 ```java
 //Positionen werden als float x und float y in der Klasse Point gespeichert
@@ -134,116 +167,131 @@ private Point position;
 private DungeonWorld level;
 
 //So können wir später dem Helden das aktuelle Level übergeben
-public void setLevel(DungeonWorld level) {
-    this.level = level;
-    //siehe unten
-    findRandomPostion();
-}
+public void setLevel(DungeonWorld level){
+        this.level=level;
+        //siehe unten
+        findRandomPostion();
+        }
 //Dem Helden eine zufällige Position im Dungeon zuweisen
 public void findRandomPostion(){
-    //Die Methode gibt ein zufälliges Bodenfeld im Dungeon zurück
-    this.position = new Point(level.getRandomPointInDungeon());
-}
+        //Die Methode gibt ein zufälliges Bodenfeld im Dungeon zurück
+        this.position=new Point(level.getRandomPointInDungeon());
+        }
 ```
 
-Jetzt wo unser Held erst einmal fertiggestellt ist, müssen wir ihn noch im Dungeon einfügen. Dies tun wir in unserer `MainController`-Klasse.
+Jetzt wo unser Held erst einmal fertiggestellt ist, müssen wir ihn noch im Dungeon einfügen. Dies tun wir in
+unserer `MainController`-Klasse.
 
-Die Methode `setup` ermöglicht es uns, einmalig zu Beginn der Anwendung Vorbereitungen zu treffen. Wir nutzen dies nun, um unseren Helden anzulegen und ihn dem `EntityController` zu übergeben.
+Die Methode `setup` ermöglicht es uns, einmalig zu Beginn der Anwendung Vorbereitungen zu treffen. Wir nutzen dies nun,
+um unseren Helden anzulegen und ihn dem `EntityController` zu übergeben.
 
 ```java
 //Unser Held
 private Hero hero;
 @Override
-public void setup() {
-    //Erstellung unseres Helden
-    hero = new Hero();
-    //Ab jetzt kümmert sich der EntityController um das aufrufen von Held.update
-    entityController.addEntity(hero);
-    //unsere Kamera soll sich immer auf den Helden zentrieren.
-    camera.follow(hero);
-}
+public void setup(){
+        //Erstellung unseres Helden
+        hero=new Hero();
+        //Ab jetzt kümmert sich der EntityController um das aufrufen von Held.update
+        entityController.addEntity(hero);
+        //unsere Kamera soll sich immer auf den Helden zentrieren.
+        camera.follow(hero);
+        }
 ```
 
-Die Kamera `camera` ist unser "Auge" im Dungeon. Mit `camera.follow` können wir ihr ein Objekt übergeben, welches von nun an immer im Mittelpunkt des Bildes sein soll.
+Die Kamera `camera` ist unser "Auge" im Dungeon. Mit `camera.follow` können wir ihr ein Objekt übergeben, welches von
+nun an immer im Mittelpunkt des Bildes sein soll.
 
 ### Sie werden platziert
 
-Jetzt müssen wir unseren Helden nur noch im Level platzieren. Dafür bietet Sich die Methode `onLevelLoad` an, diese wird immer dann automatisch aufgerufen, wenn der `LevelController` ein neues Level lädt. Der `LevelController` ist dafür zuständig, die Struktur des Dungeons zu laden und zu zeichnen. Er hält eine Referenz auf das eigentliche `DungeonWorld`-Level.
+Jetzt müssen wir unseren Helden nur noch im Level platzieren. Dafür bietet Sich die Methode `onLevelLoad` an, diese wird
+immer dann automatisch aufgerufen, wenn der `LevelController` ein neues Level lädt. Der `LevelController` ist dafür
+zuständig, die Struktur des Dungeons zu laden und zu zeichnen. Er hält eine Referenz auf das eigentliche `DungeonWorld`
+-Level.
 
-*Hinweis: Der `MainController` verfügt bereits über einen `LevelController`, welchen Sie innerhalb der Klasse mit `LevelController` ansprechen können*
+*Hinweis: Der `MainController` verfügt bereits über einen `LevelController`, welchen Sie innerhalb der Klasse
+mit `LevelController` ansprechen können*
 
 ```java
 @Override
-public void onLevelLoad() {
-    hero.setLevel(levelController.getDungeon());
-}
+public void onLevelLoad(){
+        hero.setLevel(levelController.getDungeon());
+        }
 ```
 
 Jetzt wird sich der Held bei jedem neuen Level eine zufällige Position im Dungeon suchen und sich dort positionieren.
 
-Zu guter Letzt sollten wir noch prüfen, ob unser Held auf der Leiter zum nächsten Level steht und wenn ja, das nächste Level laden (also die Leiter herab steigen in die nächste Ebene des Dungeons).
+Zu guter Letzt sollten wir noch prüfen, ob unser Held auf der Leiter zum nächsten Level steht und wenn ja, das nächste
+Level laden (also die Leiter herab steigen in die nächste Ebene des Dungeons).
 
-Die Methoden `beginFrame` und `endFrame` ermöglichen es uns, unsere eigenen Aktionen in die Game-Loop zu integrieren. Alles, was wir in der Methode `beginFrame` implementieren, wird am Anfang jedes Frames ausgeführt, analog alles in `endFrame` am Ende eines Frames.
+Die Methoden `beginFrame` und `endFrame` ermöglichen es uns, unsere eigenen Aktionen in die Game-Loop zu integrieren.
+Alles, was wir in der Methode `beginFrame` implementieren, wird am Anfang jedes Frames ausgeführt, analog alles
+in `endFrame` am Ende eines Frames.
 
 Zum Überprüfen, ob ein neues Level geladen werden soll, verwenden wir diesmal die `endFrame`-Methode.
 
 ```java
 @Override
-public void endFrame() {
-    //Prüfe ob der übergebene Point auf der Leiter ist
-    if (levelController.checkForTrigger(hero.getPosition())) {
+public void endFrame(){
+        //Prüfe ob der übergebene Point auf der Leiter ist
+        if(levelController.checkForTrigger(hero.getPosition())){
         //Lade im nächsten Frame das nächste Level
         levelController.triggerNextStage();
-    }
-}
+        }
+        }
 ```
 
 ### WSDA oder die Steuerung des Helden über die Tastatur
 
-Damit wir unser Spiel auch richtig testen können, sollten wir unserem Helden noch die Möglichkeit zum Bewegen geben. Dafür fügen wir Steuerungsoptionen in der `Held.upate`-Methode hinzu:
+Damit wir unser Spiel auch richtig testen können, sollten wir unserem Helden noch die Möglichkeit zum Bewegen geben.
+Dafür fügen wir Steuerungsoptionen in der `Held.upate`-Methode hinzu:
 
 ```java
 //Temporären Point um den Held nur zu bewegen, wenn es keine Kollision gab
-Point newPosition = new Point(this.position);
+Point newPosition=new Point(this.position);
 //Unser Held soll sich pro Schritt um 0.1 Felder bewegen.
-float movementSpeed = 0.1f;
+        float movementSpeed=0.1f;
 //Wenn die Taste W gedrückt ist, bewege dich nach oben
-if (Gdx.input.isKeyPressed(Input.Keys.W))
-    newPosition.y += movementSpeed;
+        if(Gdx.input.isKeyPressed(Input.Keys.W))
+        newPosition.y+=movementSpeed;
 //Wenn die Taste S gedrückt ist, bewege dich nach unten
-if (Gdx.input.isKeyPressed(Input.Keys.S))
-    newPosition.y -= movementSpeed;
+        if(Gdx.input.isKeyPressed(Input.Keys.S))
+        newPosition.y-=movementSpeed;
 //Wenn die Taste D gedrückt ist, bewege dich nach rechts
-if (Gdx.input.isKeyPressed(Input.Keys.D))
-    newPosition.x += movementSpeed;
+        if(Gdx.input.isKeyPressed(Input.Keys.D))
+        newPosition.x+=movementSpeed;
 //Wenn die Taste A gedrückt ist, bewege dich nach links
-if (Gdx.input.isKeyPressed(Input.Keys.A))
-    newPosition.x -= movementSpeed;
+        if(Gdx.input.isKeyPressed(Input.Keys.A))
+        newPosition.x-=movementSpeed;
 //Wenn der übergebene Punkt betretbar ist, ist das nun die aktuelle Position
-if (level.isTileAccessible(newPosition))
-   this.position = newPosition;
+        if(level.isTileAccessible(newPosition))
+        this.position=newPosition;
 ```
 
 Starten wir nun das Spiel, sollten wir in der Lage sein, unseren Helden zu sehen und durch das Dungeon zu bewegen.
 
 ### Ein letzter Überblick
 
-Unten sehen Sie eine vereinfachte Darstellung wie unser Dungeon jetzt funktioniert. Grün hinterlegte Felder müssen selbst implementiert werden, weiß hinterlegte Felder sind bereits von der API implementiert.
+Unten sehen Sie eine vereinfachte Darstellung wie unser Dungeon jetzt funktioniert. Grün hinterlegte Felder müssen
+selbst implementiert werden, weiß hinterlegte Felder sind bereits von der API implementiert.
 
 ![Vereinfachtes Sequenzdiagramm](./img/ablauf.png)
 
 ## Head-up-Display (HUD)
 
-Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung.
+Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im
+bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen
+Ihnen auch `float`-Werte zur Verfügung.
 
-Um eine Grafik auf dem HUD anzeigen zu können, erstellen wir zuerst eine neue Klasse, welche das Interface `IHUDElement` implementiert.
+Um eine Grafik auf dem HUD anzeigen zu können, erstellen wir zuerst eine neue Klasse, welche das Interface `IHUDElement`
+implementiert.
 
 ```java
 public class HeartIcon implements IHUDElement {
     @Override
     public Point getPosition() {
         //festlegen der Position
-        return new Point(0.5f,4.5f);
+        return new Point(0.5f, 4.5f);
     }
 
     @Override
@@ -254,13 +302,18 @@ public class HeartIcon implements IHUDElement {
 }
 ```
 
-Die Methode `getTexture` gibt die gewünschte Grafik als `Texture`-Objekt zurück, dies funktioniert identisch zur bereits bekannten Helden-Implementierung. Die Methode `getPosition` gibt die Position der Grafik auf dem HUD zurück. In diesem Beispiel gehen wir von einer festen Position der Grafik aus. Es wird vorkommen, dass Sie Grafiken in Abhängigkeit zu anderen Grafiken positionieren möchten, überlegen Sie sich daher bereits jetzt eine gute Struktur, um Ihre HUD-Elemente abzuspeichern.
+Die Methode `getTexture` gibt die gewünschte Grafik als `Texture`-Objekt zurück, dies funktioniert identisch zur bereits
+bekannten Helden-Implementierung. Die Methode `getPosition` gibt die Position der Grafik auf dem HUD zurück. In diesem
+Beispiel gehen wir von einer festen Position der Grafik aus. Es wird vorkommen, dass Sie Grafiken in Abhängigkeit zu
+anderen Grafiken positionieren möchten, überlegen Sie sich daher bereits jetzt eine gute Struktur, um Ihre HUD-Elemente
+abzuspeichern.
 
-Jetzt müssen wir unsere Grafik nur noch anzeigen lassen. Ähnlich zu den bereits bekannten Controllern gibt es auch für das HUD eine Steuerungsklasse, welche im `MainController` mit `hud` angesprochen werden kann.
+Jetzt müssen wir unsere Grafik nur noch anzeigen lassen. Ähnlich zu den bereits bekannten Controllern gibt es auch für
+das HUD eine Steuerungsklasse, welche im `MainController` mit `hud` angesprochen werden kann.
 
 ```java
 public class YourClass extends MainController {
-     @Override
+    @Override
     protected void setup() {
         ...
         // hinzufügen eines Elementes zum HUD
@@ -273,45 +326,58 @@ public class YourClass extends MainController {
 
 ![HUD mit Herz](./img/hudExample.PNG)
 
-Unter Umständen möchten Sie Ihre Grafiken dynamisch skalieren. Überschreiben Sie dazu die Defaultmethoden `float getWidth()` und `float getHeight()` des `IHUDElement`-Interfaces. Die Skalierung scheint nicht immer ganz logisch, scheuen Sie daher nicht, mit den Werten zu experimentieren.
+Unter Umständen möchten Sie Ihre Grafiken dynamisch skalieren. Überschreiben Sie dazu die
+Defaultmethoden `float getWidth()` und `float getHeight()` des `IHUDElement`-Interfaces. Die Skalierung scheint nicht
+immer ganz logisch, scheuen Sie daher nicht, mit den Werten zu experimentieren.
 
 ## Abschlusswort
 
-Sie haben nun die ersten Schritte im Dungeon gemacht. Von nun an müssen Sie selbst entscheiden, wie Sie die Aufgaben im Praktikum umsetzten möchten. Ihnen ist mit Sicherheit aufgefallen, dass einige Interface-Methoden in diesem Dokument noch nicht erläutert wurden. Machen Sie sich daher mit der Javadoc der API vertraut.
+Sie haben nun die ersten Schritte im Dungeon gemacht. Von nun an müssen Sie selbst entscheiden, wie Sie die Aufgaben im
+Praktikum umsetzten möchten. Ihnen ist mit Sicherheit aufgefallen, dass einige Interface-Methoden in diesem Dokument
+noch nicht erläutert wurden. Machen Sie sich daher mit der Javadoc der API vertraut.
 
 ## Zusätzliche Funktionen
 
-Hier wird eine Liste von Funktionen präsentiert, welche Sie zum Lösen der Praktikumsaufgaben zwar nicht benötigen, aber dennoch gerne verwenden können.
+Hier wird eine Liste von Funktionen präsentiert, welche Sie zum Lösen der Praktikumsaufgaben zwar nicht benötigen, aber
+dennoch gerne verwenden können.
 
 Die Liste wird in unregelmäßigen Abständen erweitert.
 
 ### Sound
 
-Möchten Sie Soundeffekte oder Hintergrundmusik zu Ihrem Dungeon hinzufügen, bietet `libGDX` eine einfache Möglichkeit dafür.
+Möchten Sie Soundeffekte oder Hintergrundmusik zu Ihrem Dungeon hinzufügen, bietet `libGDX` eine einfache Möglichkeit
+dafür.
 
-Es werden die Formate `.mp3`, `.wav` und `.ogg` unterstützt. Das Vorgehen unterscheidet sich zwischen den Formaten nicht.
+Es werden die Formate `.mp3`, `.wav` und `.ogg` unterstützt. Das Vorgehen unterscheidet sich zwischen den Formaten
+nicht.
 
 ```java
 //Datei als Sound-Objekt einladen
-Sound bumSound = Gdx.audio.newSound(Gdx.files.internal("assets/sound/bum.mp3"));
-bumSound.play();
+Sound bumSound=Gdx.audio.newSound(Gdx.files.internal("assets/sound/bum.mp3"));
+        bumSound.play();
 //Sound leise abspielen
-bumSound.play(0.1f);
+        bumSound.play(0.1f);
 //Sound mit maximal Lautstärke abspielen
-bumSound.play(1f);
+        bumSound.play(1f);
 //Soud endlos abspielen
-bumSound.loop();
+        bumSound.loop();
 ```
 
-Sie können noch weitere Parameter und Methoden verwenden, um den Sound Ihren Wünschen anzupassen. Schauen Sie dafür in die [`libGDX`-Dokumentation](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/audio/Sound.html)
+Sie können noch weitere Parameter und Methoden verwenden, um den Sound Ihren Wünschen anzupassen. Schauen Sie dafür in
+die [`libGDX`-Dokumentation](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/audio/Sound.html)
 
 ### Text
 
-Ab Version 1.1.4.0 können Sie Texte mithilfe von `TextStage` auf den Bildschirm zeichnen. Verwenden Sie dafür die `TextStage`-Instanz `textHUD`, welche bereits in Ihrem `MainController` verfügbar ist.
+Ab Version 1.1.4.0 können Sie Texte mithilfe von `TextStage` auf den Bildschirm zeichnen. Verwenden Sie dafür
+die `TextStage`-Instanz `textHUD`, welche bereits in Ihrem `MainController` verfügbar ist.
 
-Verwenden Sie die Methode `TextStage.drawText`, um einen String auf Ihren Bildschirm zu zeichnen. Sie haben dabei eine umfangreiche Auswahl an Parametern, um Ihre Einstellungen anzupassen. Beachten Sie, dass die Positionen des Texts dieses Mal in "echten Pixeln" angegeben werden muss (wir arbeiten bereits daran, ein einheitliches Positionssystem zu entwickeln, bis dahin müssen Sie leider mit den unterschiedlichen Systemen arbeiten).
+Verwenden Sie die Methode `TextStage.drawText`, um einen String auf Ihren Bildschirm zu zeichnen. Sie haben dabei eine
+umfangreiche Auswahl an Parametern, um Ihre Einstellungen anzupassen. Beachten Sie, dass die Positionen des Texts dieses
+Mal in "echten Pixeln" angegeben werden muss (wir arbeiten bereits daran, ein einheitliches Positionssystem zu
+entwickeln, bis dahin müssen Sie leider mit den unterschiedlichen Systemen arbeiten).
 
-`TextStage.drawText` gibt Ihnen ein `Label`-Objekt zurück, dieses können Sie verwenden, um den Text später anzupassen oder ihn vom Bildschirm zu entfernen.
+`TextStage.drawText` gibt Ihnen ein `Label`-Objekt zurück, dieses können Sie verwenden, um den Text später anzupassen
+oder ihn vom Bildschirm zu entfernen.
 
 Im unteren Beispiel wird ein Text implementiert, welcher das aktuelle Level ausgibt.
 
@@ -319,14 +385,14 @@ Im unteren Beispiel wird ein Text implementiert, welcher das aktuelle Level ausg
 public class MyMain extends MainController {
     .....
     Label levelLabel;
-    int levelCounter=0;
+    int levelCounter = 0;
+
     public void onLevelLoad() {
         levelCounter++;
-        if (levelCounter==1){
-            levelLabel=textHUD.drawText("Level"+x,"PATH/TO/FONT.ttf",Color.RED,30,50,50,30,30);
-        }
-        else{
-            levelLabel.setText("Level"+x)
+        if (levelCounter == 1) {
+            levelLabel = textHUD.drawText("Level" + x, "PATH/TO/FONT.ttf", Color.RED, 30, 50, 50, 30, 30);
+        } else {
+            levelLabel.setText("Level" + x)
         }
     }
     //remove label
@@ -338,5 +404,5 @@ public class MyMain extends MainController {
 
 Genauere Informationen zu den Parametern entnehmen Sie bitte der JavaDoc.
 
-
-*Hinweis: Achten Sie darauf, Daten nur dann in öffentliche Git-Repos zu laden, wenn Sie die nötigen Rechte an diesen Daten haben. Dies gilt insbesondere auch für Artefakte wie Bilder, Bitmaps, Musik oder Soundeffekte.*
+*Hinweis: Achten Sie darauf, Daten nur dann in öffentliche Git-Repos zu laden, wenn Sie die nötigen Rechte an diesen
+Daten haben. Dies gilt insbesondere auch für Artefakte wie Bilder, Bitmaps, Musik oder Soundeffekte.*

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 ---
 title: "Dokumentation zum PM-Dungeon"
 author: "André Matutat"
-lang: de-DE ...
+lang: de-DE
+...
+
+
 
 ## Einleitung
 
-Dieses Dokument liefert einen Einstieg in das PM-Dungeon. Es erläutert die Installation der API und erläutert Ihnen die
-ersten Schritte, um eigene Inhalte zum Dungeon hinzuzufügen. Es dient als Grundlage für alle weiteren Praktika. Lesen
-Sie das Dokument daher aufmerksam durch und versuchen Sie sich zusätzlich selbst mit dem Aufbau vertraut zu machen.
+Dieses Dokument liefert einen Einstieg in das PM-Dungeon. Es erläutert die Installation der API und erläutert Ihnen die ersten Schritte, um eigene Inhalte zum Dungeon hinzuzufügen. Es dient als Grundlage für alle weiteren Praktika. Lesen Sie das Dokument daher aufmerksam durch und versuchen Sie sich zusätzlich selbst mit dem Aufbau vertraut zu machen.
 
 ## Installation
 
-- Laden Sie sich das `pmdungeon.jar` und den `assets`-Ordner mit Texturen und Level-Beschreibungen herunter.
-  Das `pmdungeon.jar` wird Ihnen als API dienen.
+- Laden Sie sich das `pmdungeon.jar` und den `assets`-Ordner mit Texturen und Level-Beschreibungen herunter. Das `pmdungeon.jar` wird Ihnen als API dienen.
 - Erstellen Sie in Ihrer IDE ein neues Java-Projekt
 - Integrieren Sie die `pmdungeon.jar` als Library in Ihrem Projekt
 - Kopieren Sie den `assets`-Ordner in Ihr Projektverzeichnis
@@ -21,27 +21,13 @@ Sie das Dokument daher aufmerksam durch und versuchen Sie sich zusätzlich selbs
 
 Zu Beginn einige grundlegende Prinzipien, die Sie verstanden haben sollten, bevor Sie mit dem Dungeon arbeiten.
 
-- Das PM-Dungeon wird mithilfe des Cross-Plattform Java-Frameworks [`libGDX`](https://libgdx.com) umgesetzt. Dieses ist
-  in der `pmdungeon.jar` bereits integriert, Sie müssen dieses nicht extra installieren. Die Ihnen zur Verfügung
-  gestellten Vorgaben sind so umgesetzt, dass Sie kein tieferes Verständnis für das Framework benötigen, um die Aufgaben
-  zu lösen. Sollten Sie allerdings einmal auf Probleme stoßen, kann es unter Umständen helfen, einen Blick in die
-  Dokumentation von `libGDX` zu werfen.
-- Die API enthält bereits einige vordefinierte Spiel-Level (Ebenen im Dungeon). Sie müssen sich daher nicht mit der
-  Generierung von Dungeons auseinandersetzen. Level werden als 2D-Array gespeichert, wobei jedes Feld entweder ein
-  Boden, eine Wand oder `null` sein kann.
-- Zwar wird das Level als 2D-Array gespeichert und daher sind Koordinaten auch als Integer-Tupel bestimmbar, allerdings
-  verwendet die API intern virtuelle Einheiten. (Welche Vorteile dieses Vorgehen liefert können
-  Sie [hier](https://xoppa.github.io/blog/pixels/) nachlesen). Daher lassen sich Entitäten auch zwischen den Feldern
-  zeichnen.
+- Das PM-Dungeon wird mithilfe des Cross-Plattform Java-Frameworks [`libGDX`](https://libgdx.com) umgesetzt. Dieses ist in der `pmdungeon.jar` bereits integriert, Sie müssen dieses nicht extra installieren. Die Ihnen zur Verfügung gestellten Vorgaben sind so umgesetzt, dass Sie kein tieferes Verständnis für das Framework benötigen, um die Aufgaben zu lösen. Sollten Sie allerdings einmal auf Probleme stoßen, kann es unter Umständen helfen, einen Blick in die Dokumentation von `libGDX` zu werfen.
+- Die API enthält bereits einige vordefinierte Spiel-Level (Ebenen im Dungeon). Sie müssen sich daher nicht mit der Generierung von Dungeons auseinandersetzen. Level werden als 2D-Array gespeichert, wobei jedes Feld entweder ein Boden, eine Wand oder `null` sein kann.
+- Zwar wird das Level als 2D-Array gespeichert und daher sind Koordinaten auch als Integer-Tupel bestimmbar, allerdings verwendet die API intern virtuelle Einheiten. (Welche Vorteile dieses Vorgehen liefert können Sie [hier](https://xoppa.github.io/blog/pixels/) nachlesen). Daher lassen sich Entitäten auch zwischen den Feldern zeichnen.
 
 ![Positionen am Beispiel der X-Position](./img/x+1.png)
 
-- Game-Loop: Die Game-Loop ist die wichtigste Komponente des Spieles. Sie ist eine Endlosschleife, welche einmal
-  pro [Frame](https://de.wikipedia.org/wiki/Bildfrequenz) aufgerufen wird. Das Spiel läuft in 30-FPS (also 30 *frames
-  per seconds*, zu Deutsch 30 Bildern pro Sekunde), die Game-Loop wird also 30mal in der Sekunde aufgerufen. Alle
-  Aktionen, die wiederholt ausgeführt werden müssen, wie zum Beispiel das Bewegen und Zeichnen von Figuren, müssen
-  innerhalb der Game-Loop stattfinden. Die API ermöglicht es Ihnen, eigene Aktionen in die Game-Loop zu integrieren. Wie
-  genau das geht, erfahren Sie im Laufe dieser Dokumentation.
+- Game-Loop: Die Game-Loop ist die wichtigste Komponente des Spieles. Sie ist eine Endlosschleife, welche einmal pro [Frame](https://de.wikipedia.org/wiki/Bildfrequenz) aufgerufen wird. Das Spiel läuft in 30-FPS (also 30 *frames per seconds*, zu Deutsch 30 Bildern pro Sekunde), die Game-Loop wird also 30mal in der Sekunde aufgerufen. Alle Aktionen, die wiederholt ausgeführt werden müssen, wie zum Beispiel das Bewegen und Zeichnen von Figuren, müssen innerhalb der Game-Loop stattfinden. Die API ermöglicht es Ihnen, eigene Aktionen in die Game-Loop zu integrieren. Wie genau das geht, erfahren Sie im Laufe dieser Dokumentation.
 
   *Hinweis: Die Game-Loop wird automatisch ausgeführt, Sie müssen sie nicht aktiv aufrufen.*
 
@@ -55,10 +41,10 @@ In diesen Abschnitt werden alle Schritte erläutert, die zum ersten Start der An
 
 - Überschreiben Sie alle notwendigen Methoden:
 
-    - `protected void setup()`
-    - `protected void beginFrame()`
-    - `protected void endFrame()`
-    - `public void onLevelLoad()`
+  - `protected void setup()`
+  - `protected void beginFrame()`
+  - `protected void endFrame()`
+  - `public void onLevelLoad()`
 
   *Hinweis: Weitere Informationen zu diesen Methoden erfolgen im Laufe der Dokumentation.*
 
@@ -71,25 +57,15 @@ In diesen Abschnitt werden alle Schritte erläutert, die zum ersten Start der An
     }
     ```
 
-Das Spiel sollte nun starten und Sie sollten ein schwarzes Fenster mit einem Teil des Dungeons in der oberen rechten
-Ecke sehen.
+Das Spiel sollte nun starten und Sie sollten ein schwarzes Fenster mit einem Teil des Dungeons in der oberen rechten Ecke sehen.
 
-Bevor wir nun unseren Helden implementieren sollten wir verstehen, was genau der `MainController` eigentlich ist. Wie
-der Name schon vermuten lässt, ist dies die Haupt-Steuerung des Spiels. Er bereitet alles für den Start des Spieles vor,
-verwaltet die anderen Controller und enthält die Game-Loop. Wir nutzen unsere Klasse, welche vom `MainController` erbt,
-um selbst in die Game-Loop einzugreifen und unsere eigenen Objekte wie Helden und Monster zu verwalten.
-Der `MainController` ist der Punkt, an dem alle Fäden des Dungeons zusammenlaufen. Im Folgenden wird Ihnen erklärt, wie
-Sie erfolgreich mit dem `MainController` arbeiten.
+Bevor wir nun unseren Helden implementieren sollten wir verstehen, was genau der `MainController` eigentlich ist. Wie der Name schon vermuten lässt, ist dies die Haupt-Steuerung des Spiels. Er bereitet alles für den Start des Spieles vor, verwaltet die anderen Controller und enthält die Game-Loop. Wir nutzen unsere Klasse, welche vom `MainController` erbt, um selbst in die Game-Loop einzugreifen und unsere eigenen Objekte wie Helden und Monster zu verwalten. Der `MainController` ist der Punkt, an dem alle Fäden des Dungeons zusammenlaufen. Im Folgenden wird Ihnen erklärt, wie Sie erfolgreich mit dem `MainController` arbeiten.
 
 ## Eigener Held
 
-Jetzt, wo Sie sichergestellt haben, dass das Dungeon ausgeführt werden kann, geht es darum, das Spiel mit Ihren Inhalten
-zu erweitern. Im Folgenden wird ein rudimentärer Held implementiert, um Ihnen die verschiedenen Aspekte des Dungeon zu
-erläutern.
+Jetzt, wo Sie sichergestellt haben, dass das Dungeon ausgeführt werden kann, geht es darum, das Spiel mit Ihren Inhalten zu erweitern. Im Folgenden wird ein rudimentärer Held implementiert, um Ihnen die verschiedenen Aspekte des Dungeon zu erläutern.
 
-Fangen wir damit an eine neue Klasse für den Helden anzulegen. Da unser Held eine Animation haben soll, implementieren
-wir das Interface `IAnimatable`. Dies erlaubt es uns, unseren Helden zu animieren. Für Objekte, die keine Animation
-haben, sondern nur eine Textur, würden wir das Interface `IDrawable` implementieren.
+Fangen wir damit an eine neue Klasse für den Helden anzulegen. Da unser Held eine Animation haben soll, implementieren wir das Interface `IAnimatable`. Dies erlaubt es uns, unseren Helden zu animieren. Für Objekte, die keine Animation haben, sondern nur eine Textur, würden wir das Interface `IDrawable` implementieren.
 
 ```java
 public class Hero implements IAnimatable {
@@ -100,43 +76,37 @@ public class Hero implements IAnimatable {
 
 ### Der bewegte (animierte) Held
 
-Fangen wir damit an, die Animation für unseren Helden zu erstellen. Eine Animation ist eine Liste mit verschieden
-Texturen, die nacheinander abgespielt werden.
+Fangen wir damit an, die Animation für unseren Helden zu erstellen. Eine Animation ist eine Liste mit verschieden Texturen, die nacheinander abgespielt werden.
 
 ```java
 //Anlegen einer Animation
 private Animation idleAnimation;
-public Hero(){
-        //Erstellen einer ArrayList
-        List<Texture> idle=new ArrayList<>();
-        //Laden der Texturen für die Animation (Pfad angeben)
-        idle.add(new Texture(PATH_TO_TEXTURE_1.png));
-        idle.add(new Texture(PATH_TO_TEXTURE_1.png));
-        //Erstellen einer Animation, als Parameter wird die Liste mit den Texturen
-        //und die Wartezeit (in Frames) zwischen den Wechsel der Texturen angegeben
-        idleAnimation=new Animation(idle,8);
-        }
+public Hero() {
+    //Erstellen einer ArrayList
+    List <Texture> idle = new ArrayList<>();
+    //Laden der Texturen für die Animation (Pfad angeben)
+    idle.add(new Texture(PATH_TO_TEXTURE_1.png));
+    idle.add(new Texture(PATH_TO_TEXTURE_1.png));
+    //Erstellen einer Animation, als Parameter wird die Liste mit den Texturen
+    //und die Wartezeit (in Frames) zwischen den Wechsel der Texturen angegeben
+    idleAnimation = new Animation(idle,8);
+}
 
 @Override
 //Da unser Held aktuell nur eine Animation hat,
 //geben wir diese als aktuell aktive Animation zurück
-public Animation getActiveAnimation(){
-        return this.idle;
-        }
+public Animation getActiveAnimation() {
+    return this.idle;
+}
 ```
 
 Super, jetzt hat unser Held eine Animation. Nun muss diese noch im Spiel gezeichnet werden.
 
-Da das Dungeon framebasiert ist, muss unser Held in jedem Frame (also 30-mal in der Sekunde) neu gezeichnet werden. Dazu
-verwenden Wir das `IEntity` Interface, welches uns erlaubt Objekte vom `EntityController` managen zu lassen.
+Da das Dungeon framebasiert ist, muss unser Held in jedem Frame (also 30-mal in der Sekunde) neu gezeichnet werden. Dazu verwenden Wir das `IEntity` Interface, welches uns erlaubt Objekte vom `EntityController` managen zu lassen.
 
-Der `EntityController` verwendet das *Observer-Pattern* (vergleiche Vorlesung) um Instanzen vom Typen `IEntity` zu
-verwalten. Er sorgt dafür, dass die vom Interface bereitgestellte `update`-Methode jeder Entität in der Game-Loop
-aufgerufen wird. Dazu hält er eine Liste mit allen ihm übergebenen Entitäten. Weiter unten sehen Sie, wie Sie
-den `EntityController` verwenden können, um unseren Helden managen zu lassen.
+Der `EntityController` verwendet das *Observer-Pattern* (vergleiche Vorlesung) um Instanzen vom Typen `IEntity` zu verwalten. Er sorgt dafür, dass die vom Interface bereitgestellte `update`-Methode jeder Entität in der Game-Loop aufgerufen wird. Dazu hält er eine Liste mit allen ihm übergebenen Entitäten. Weiter unten sehen Sie, wie Sie den `EntityController` verwenden können, um unseren Helden managen zu lassen.
 
-*Hinweis: Der `MainController` verfügt bereits über einen `EntityController`, welchen Sie innerhalb der Klasse
-mit `entityController` ansprechen können*
+*Hinweis: Der `MainController` verfügt bereits über einen `EntityController`, welchen Sie innerhalb der Klasse mit `entityController` ansprechen können*
 
 Dafür implementiert unser Held nun zusätzlich das `IEntity`-Interface und die `update`-Methode.
 
@@ -155,10 +125,7 @@ public class Hero implements IAnimatable, IEntity {
 
 ### Wo bin ich?
 
-Jetzt ist unsere erste Version vom Helden fast fertig, wir benötigen lediglich noch ein paar kleinere Informationen.
-Zuerst muss unser Held wissen, wo er überhaupt im Dungeon steht, dafür benötigt er eine Position. Zusätzlich wäre es
-hilfreich, wenn unser Held das Level (die Dungeon-Ebene) kennen würde, da wir so vermeiden können, dass sich unser Held
-durch Wände bewegt oder sich außerhalb des eigentlichen Spielbereiches aufhält.
+Jetzt ist unsere erste Version vom Helden fast fertig, wir benötigen lediglich noch ein paar kleinere Informationen. Zuerst muss unser Held wissen, wo er überhaupt im Dungeon steht, dafür benötigt er eine Position. Zusätzlich wäre es hilfreich, wenn unser Held das Level (die Dungeon-Ebene) kennen würde, da wir so vermeiden können, dass sich unser Held durch Wände bewegt oder sich außerhalb des eigentlichen Spielbereiches aufhält.
 
 ```java
 //Positionen werden als float x und float y in der Klasse Point gespeichert
@@ -167,131 +134,116 @@ private Point position;
 private DungeonWorld level;
 
 //So können wir später dem Helden das aktuelle Level übergeben
-public void setLevel(DungeonWorld level){
-        this.level=level;
-        //siehe unten
-        findRandomPostion();
-        }
+public void setLevel(DungeonWorld level) {
+    this.level = level;
+    //siehe unten
+    findRandomPostion();
+}
 //Dem Helden eine zufällige Position im Dungeon zuweisen
 public void findRandomPostion(){
-        //Die Methode gibt ein zufälliges Bodenfeld im Dungeon zurück
-        this.position=new Point(level.getRandomPointInDungeon());
-        }
+    //Die Methode gibt ein zufälliges Bodenfeld im Dungeon zurück
+    this.position = new Point(level.getRandomPointInDungeon());
+}
 ```
 
-Jetzt wo unser Held erst einmal fertiggestellt ist, müssen wir ihn noch im Dungeon einfügen. Dies tun wir in
-unserer `MainController`-Klasse.
+Jetzt wo unser Held erst einmal fertiggestellt ist, müssen wir ihn noch im Dungeon einfügen. Dies tun wir in unserer `MainController`-Klasse.
 
-Die Methode `setup` ermöglicht es uns, einmalig zu Beginn der Anwendung Vorbereitungen zu treffen. Wir nutzen dies nun,
-um unseren Helden anzulegen und ihn dem `EntityController` zu übergeben.
+Die Methode `setup` ermöglicht es uns, einmalig zu Beginn der Anwendung Vorbereitungen zu treffen. Wir nutzen dies nun, um unseren Helden anzulegen und ihn dem `EntityController` zu übergeben.
 
 ```java
 //Unser Held
 private Hero hero;
 @Override
-public void setup(){
-        //Erstellung unseres Helden
-        hero=new Hero();
-        //Ab jetzt kümmert sich der EntityController um das aufrufen von Held.update
-        entityController.addEntity(hero);
-        //unsere Kamera soll sich immer auf den Helden zentrieren.
-        camera.follow(hero);
-        }
+public void setup() {
+    //Erstellung unseres Helden
+    hero = new Hero();
+    //Ab jetzt kümmert sich der EntityController um das aufrufen von Held.update
+    entityController.addEntity(hero);
+    //unsere Kamera soll sich immer auf den Helden zentrieren.
+    camera.follow(hero);
+}
 ```
 
-Die Kamera `camera` ist unser "Auge" im Dungeon. Mit `camera.follow` können wir ihr ein Objekt übergeben, welches von
-nun an immer im Mittelpunkt des Bildes sein soll.
+Die Kamera `camera` ist unser "Auge" im Dungeon. Mit `camera.follow` können wir ihr ein Objekt übergeben, welches von nun an immer im Mittelpunkt des Bildes sein soll.
 
 ### Sie werden platziert
 
-Jetzt müssen wir unseren Helden nur noch im Level platzieren. Dafür bietet Sich die Methode `onLevelLoad` an, diese wird
-immer dann automatisch aufgerufen, wenn der `LevelController` ein neues Level lädt. Der `LevelController` ist dafür
-zuständig, die Struktur des Dungeons zu laden und zu zeichnen. Er hält eine Referenz auf das eigentliche `DungeonWorld`
--Level.
+Jetzt müssen wir unseren Helden nur noch im Level platzieren. Dafür bietet Sich die Methode `onLevelLoad` an, diese wird immer dann automatisch aufgerufen, wenn der `LevelController` ein neues Level lädt. Der `LevelController` ist dafür zuständig, die Struktur des Dungeons zu laden und zu zeichnen. Er hält eine Referenz auf das eigentliche `DungeonWorld`-Level.
 
-*Hinweis: Der `MainController` verfügt bereits über einen `LevelController`, welchen Sie innerhalb der Klasse
-mit `LevelController` ansprechen können*
+*Hinweis: Der `MainController` verfügt bereits über einen `LevelController`, welchen Sie innerhalb der Klasse mit `LevelController` ansprechen können*
 
 ```java
 @Override
-public void onLevelLoad(){
-        hero.setLevel(levelController.getDungeon());
-        }
+public void onLevelLoad() {
+    hero.setLevel(levelController.getDungeon());
+}
 ```
 
 Jetzt wird sich der Held bei jedem neuen Level eine zufällige Position im Dungeon suchen und sich dort positionieren.
 
-Zu guter Letzt sollten wir noch prüfen, ob unser Held auf der Leiter zum nächsten Level steht und wenn ja, das nächste
-Level laden (also die Leiter herab steigen in die nächste Ebene des Dungeons).
+Zu guter Letzt sollten wir noch prüfen, ob unser Held auf der Leiter zum nächsten Level steht und wenn ja, das nächste Level laden (also die Leiter herab steigen in die nächste Ebene des Dungeons).
 
-Die Methoden `beginFrame` und `endFrame` ermöglichen es uns, unsere eigenen Aktionen in die Game-Loop zu integrieren.
-Alles, was wir in der Methode `beginFrame` implementieren, wird am Anfang jedes Frames ausgeführt, analog alles
-in `endFrame` am Ende eines Frames.
+Die Methoden `beginFrame` und `endFrame` ermöglichen es uns, unsere eigenen Aktionen in die Game-Loop zu integrieren. Alles, was wir in der Methode `beginFrame` implementieren, wird am Anfang jedes Frames ausgeführt, analog alles in `endFrame` am Ende eines Frames.
 
 Zum Überprüfen, ob ein neues Level geladen werden soll, verwenden wir diesmal die `endFrame`-Methode.
 
 ```java
 @Override
-public void endFrame(){
-        //Prüfe ob der übergebene Point auf der Leiter ist
-        if(levelController.checkForTrigger(hero.getPosition())){
+public void endFrame() {
+    //Prüfe ob der übergebene Point auf der Leiter ist
+    if (levelController.checkForTrigger(hero.getPosition())) {
         //Lade im nächsten Frame das nächste Level
         levelController.triggerNextStage();
-        }
-        }
+    }
+}
 ```
 
 ### WSDA oder die Steuerung des Helden über die Tastatur
 
-Damit wir unser Spiel auch richtig testen können, sollten wir unserem Helden noch die Möglichkeit zum Bewegen geben.
-Dafür fügen wir Steuerungsoptionen in der `Held.upate`-Methode hinzu:
+Damit wir unser Spiel auch richtig testen können, sollten wir unserem Helden noch die Möglichkeit zum Bewegen geben. Dafür fügen wir Steuerungsoptionen in der `Held.upate`-Methode hinzu:
 
 ```java
 //Temporären Point um den Held nur zu bewegen, wenn es keine Kollision gab
-Point newPosition=new Point(this.position);
+Point newPosition = new Point(this.position);
 //Unser Held soll sich pro Schritt um 0.1 Felder bewegen.
-        float movementSpeed=0.1f;
+float movementSpeed = 0.1f;
 //Wenn die Taste W gedrückt ist, bewege dich nach oben
-        if(Gdx.input.isKeyPressed(Input.Keys.W))
-        newPosition.y+=movementSpeed;
+if (Gdx.input.isKeyPressed(Input.Keys.W))
+    newPosition.y += movementSpeed;
 //Wenn die Taste S gedrückt ist, bewege dich nach unten
-        if(Gdx.input.isKeyPressed(Input.Keys.S))
-        newPosition.y-=movementSpeed;
+if (Gdx.input.isKeyPressed(Input.Keys.S))
+    newPosition.y -= movementSpeed;
 //Wenn die Taste D gedrückt ist, bewege dich nach rechts
-        if(Gdx.input.isKeyPressed(Input.Keys.D))
-        newPosition.x+=movementSpeed;
+if (Gdx.input.isKeyPressed(Input.Keys.D))
+    newPosition.x += movementSpeed;
 //Wenn die Taste A gedrückt ist, bewege dich nach links
-        if(Gdx.input.isKeyPressed(Input.Keys.A))
-        newPosition.x-=movementSpeed;
+if (Gdx.input.isKeyPressed(Input.Keys.A))
+    newPosition.x -= movementSpeed;
 //Wenn der übergebene Punkt betretbar ist, ist das nun die aktuelle Position
-        if(level.isTileAccessible(newPosition))
-        this.position=newPosition;
+if (level.isTileAccessible(newPosition))
+   this.position = newPosition;
 ```
 
 Starten wir nun das Spiel, sollten wir in der Lage sein, unseren Helden zu sehen und durch das Dungeon zu bewegen.
 
 ### Ein letzter Überblick
 
-Unten sehen Sie eine vereinfachte Darstellung wie unser Dungeon jetzt funktioniert. Grün hinterlegte Felder müssen
-selbst implementiert werden, weiß hinterlegte Felder sind bereits von der API implementiert.
+Unten sehen Sie eine vereinfachte Darstellung wie unser Dungeon jetzt funktioniert. Grün hinterlegte Felder müssen selbst implementiert werden, weiß hinterlegte Felder sind bereits von der API implementiert.
 
 ![Vereinfachtes Sequenzdiagramm](./img/ablauf.png)
 
 ## Head-up-Display (HUD)
 
-Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im
-bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen
-Ihnen auch `float`-Werte zur Verfügung.
+Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung.
 
-Um eine Grafik auf dem HUD anzeigen zu können, erstellen wir zuerst eine neue Klasse, welche das Interface `IHUDElement`
-implementiert.
+Um eine Grafik auf dem HUD anzeigen zu können, erstellen wir zuerst eine neue Klasse, welche das Interface `IHUDElement` implementiert.
 
 ```java
 public class HeartIcon implements IHUDElement {
     @Override
     public Point getPosition() {
         //festlegen der Position
-        return new Point(0.5f, 4.5f);
+        return new Point(0.5f,4.5f);
     }
 
     @Override
@@ -302,18 +254,13 @@ public class HeartIcon implements IHUDElement {
 }
 ```
 
-Die Methode `getTexture` gibt die gewünschte Grafik als `Texture`-Objekt zurück, dies funktioniert identisch zur bereits
-bekannten Helden-Implementierung. Die Methode `getPosition` gibt die Position der Grafik auf dem HUD zurück. In diesem
-Beispiel gehen wir von einer festen Position der Grafik aus. Es wird vorkommen, dass Sie Grafiken in Abhängigkeit zu
-anderen Grafiken positionieren möchten, überlegen Sie sich daher bereits jetzt eine gute Struktur, um Ihre HUD-Elemente
-abzuspeichern.
+Die Methode `getTexture` gibt die gewünschte Grafik als `Texture`-Objekt zurück, dies funktioniert identisch zur bereits bekannten Helden-Implementierung. Die Methode `getPosition` gibt die Position der Grafik auf dem HUD zurück. In diesem Beispiel gehen wir von einer festen Position der Grafik aus. Es wird vorkommen, dass Sie Grafiken in Abhängigkeit zu anderen Grafiken positionieren möchten, überlegen Sie sich daher bereits jetzt eine gute Struktur, um Ihre HUD-Elemente abzuspeichern.
 
-Jetzt müssen wir unsere Grafik nur noch anzeigen lassen. Ähnlich zu den bereits bekannten Controllern gibt es auch für
-das HUD eine Steuerungsklasse, welche im `MainController` mit `hud` angesprochen werden kann.
+Jetzt müssen wir unsere Grafik nur noch anzeigen lassen. Ähnlich zu den bereits bekannten Controllern gibt es auch für das HUD eine Steuerungsklasse, welche im `MainController` mit `hud` angesprochen werden kann.
 
 ```java
 public class YourClass extends MainController {
-    @Override
+     @Override
     protected void setup() {
         ...
         // hinzufügen eines Elementes zum HUD
@@ -326,58 +273,45 @@ public class YourClass extends MainController {
 
 ![HUD mit Herz](./img/hudExample.PNG)
 
-Unter Umständen möchten Sie Ihre Grafiken dynamisch skalieren. Überschreiben Sie dazu die
-Defaultmethoden `float getWidth()` und `float getHeight()` des `IHUDElement`-Interfaces. Die Skalierung scheint nicht
-immer ganz logisch, scheuen Sie daher nicht, mit den Werten zu experimentieren.
+Unter Umständen möchten Sie Ihre Grafiken dynamisch skalieren. Überschreiben Sie dazu die Defaultmethoden `float getWidth()` und `float getHeight()` des `IHUDElement`-Interfaces. Die Skalierung scheint nicht immer ganz logisch, scheuen Sie daher nicht, mit den Werten zu experimentieren.
 
 ## Abschlusswort
 
-Sie haben nun die ersten Schritte im Dungeon gemacht. Von nun an müssen Sie selbst entscheiden, wie Sie die Aufgaben im
-Praktikum umsetzten möchten. Ihnen ist mit Sicherheit aufgefallen, dass einige Interface-Methoden in diesem Dokument
-noch nicht erläutert wurden. Machen Sie sich daher mit der Javadoc der API vertraut.
+Sie haben nun die ersten Schritte im Dungeon gemacht. Von nun an müssen Sie selbst entscheiden, wie Sie die Aufgaben im Praktikum umsetzten möchten. Ihnen ist mit Sicherheit aufgefallen, dass einige Interface-Methoden in diesem Dokument noch nicht erläutert wurden. Machen Sie sich daher mit der Javadoc der API vertraut.
 
 ## Zusätzliche Funktionen
 
-Hier wird eine Liste von Funktionen präsentiert, welche Sie zum Lösen der Praktikumsaufgaben zwar nicht benötigen, aber
-dennoch gerne verwenden können.
+Hier wird eine Liste von Funktionen präsentiert, welche Sie zum Lösen der Praktikumsaufgaben zwar nicht benötigen, aber dennoch gerne verwenden können.
 
 Die Liste wird in unregelmäßigen Abständen erweitert.
 
 ### Sound
 
-Möchten Sie Soundeffekte oder Hintergrundmusik zu Ihrem Dungeon hinzufügen, bietet `libGDX` eine einfache Möglichkeit
-dafür.
+Möchten Sie Soundeffekte oder Hintergrundmusik zu Ihrem Dungeon hinzufügen, bietet `libGDX` eine einfache Möglichkeit dafür.
 
-Es werden die Formate `.mp3`, `.wav` und `.ogg` unterstützt. Das Vorgehen unterscheidet sich zwischen den Formaten
-nicht.
+Es werden die Formate `.mp3`, `.wav` und `.ogg` unterstützt. Das Vorgehen unterscheidet sich zwischen den Formaten nicht.
 
 ```java
 //Datei als Sound-Objekt einladen
-Sound bumSound=Gdx.audio.newSound(Gdx.files.internal("assets/sound/bum.mp3"));
-        bumSound.play();
+Sound bumSound = Gdx.audio.newSound(Gdx.files.internal("assets/sound/bum.mp3"));
+bumSound.play();
 //Sound leise abspielen
-        bumSound.play(0.1f);
+bumSound.play(0.1f);
 //Sound mit maximal Lautstärke abspielen
-        bumSound.play(1f);
+bumSound.play(1f);
 //Soud endlos abspielen
-        bumSound.loop();
+bumSound.loop();
 ```
 
-Sie können noch weitere Parameter und Methoden verwenden, um den Sound Ihren Wünschen anzupassen. Schauen Sie dafür in
-die [`libGDX`-Dokumentation](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/audio/Sound.html)
+Sie können noch weitere Parameter und Methoden verwenden, um den Sound Ihren Wünschen anzupassen. Schauen Sie dafür in die [`libGDX`-Dokumentation](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/audio/Sound.html)
 
 ### Text
 
-Ab Version 1.1.4.0 können Sie Texte mithilfe von `TextStage` auf den Bildschirm zeichnen. Verwenden Sie dafür
-die `TextStage`-Instanz `textHUD`, welche bereits in Ihrem `MainController` verfügbar ist.
+Ab Version 1.1.4.0 können Sie Texte mithilfe von `TextStage` auf den Bildschirm zeichnen. Verwenden Sie dafür die `TextStage`-Instanz `textHUD`, welche bereits in Ihrem `MainController` verfügbar ist.
 
-Verwenden Sie die Methode `TextStage.drawText`, um einen String auf Ihren Bildschirm zu zeichnen. Sie haben dabei eine
-umfangreiche Auswahl an Parametern, um Ihre Einstellungen anzupassen. Beachten Sie, dass die Positionen des Texts dieses
-Mal in "echten Pixeln" angegeben werden muss (wir arbeiten bereits daran, ein einheitliches Positionssystem zu
-entwickeln, bis dahin müssen Sie leider mit den unterschiedlichen Systemen arbeiten).
+Verwenden Sie die Methode `TextStage.drawText`, um einen String auf Ihren Bildschirm zu zeichnen. Sie haben dabei eine umfangreiche Auswahl an Parametern, um Ihre Einstellungen anzupassen. Beachten Sie, dass die Positionen des Texts dieses Mal in "echten Pixeln" angegeben werden muss (wir arbeiten bereits daran, ein einheitliches Positionssystem zu entwickeln, bis dahin müssen Sie leider mit den unterschiedlichen Systemen arbeiten).
 
-`TextStage.drawText` gibt Ihnen ein `Label`-Objekt zurück, dieses können Sie verwenden, um den Text später anzupassen
-oder ihn vom Bildschirm zu entfernen.
+`TextStage.drawText` gibt Ihnen ein `Label`-Objekt zurück, dieses können Sie verwenden, um den Text später anzupassen oder ihn vom Bildschirm zu entfernen.
 
 Im unteren Beispiel wird ein Text implementiert, welcher das aktuelle Level ausgibt.
 
@@ -385,14 +319,14 @@ Im unteren Beispiel wird ein Text implementiert, welcher das aktuelle Level ausg
 public class MyMain extends MainController {
     .....
     Label levelLabel;
-    int levelCounter = 0;
-
+    int levelCounter=0;
     public void onLevelLoad() {
         levelCounter++;
-        if (levelCounter == 1) {
-            levelLabel = textHUD.drawText("Level" + x, "PATH/TO/FONT.ttf", Color.RED, 30, 50, 50, 30, 30);
-        } else {
-            levelLabel.setText("Level" + x)
+        if (levelCounter==1){
+            levelLabel=textHUD.drawText("Level"+x,"PATH/TO/FONT.ttf",Color.RED,30,50,50,30,30);
+        }
+        else{
+            levelLabel.setText("Level"+x)
         }
     }
     //remove label
@@ -404,5 +338,5 @@ public class MyMain extends MainController {
 
 Genauere Informationen zu den Parametern entnehmen Sie bitte der JavaDoc.
 
-*Hinweis: Achten Sie darauf, Daten nur dann in öffentliche Git-Repos zu laden, wenn Sie die nötigen Rechte an diesen
-Daten haben. Dies gilt insbesondere auch für Artefakte wie Bilder, Bitmaps, Musik oder Soundeffekte.*
+
+*Hinweis: Achten Sie darauf, Daten nur dann in öffentliche Git-Repos zu laden, wenn Sie die nötigen Rechte an diesen Daten haben. Dies gilt insbesondere auch für Artefakte wie Bilder, Bitmaps, Musik oder Soundeffekte.*

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    
+
 
     repositories {
         mavenLocal()
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        
+
 
     }
 }
@@ -52,7 +52,7 @@ project(":desktop") {
         api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
         api "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
         implementation "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
-        
+
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,6 +3,6 @@ apply plugin: "java"
 sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
-sourceSets.main.java.srcDirs = [ "src/" ]
+sourceSets.main.java.srcDirs = ["src/"]
 
 eclipse.project.name = appName + "-core"

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/HorizontalWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/HorizontalWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class HorizontalWall extends WallPattern {
 
     public HorizontalWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/LowerRightCornerWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/LowerRightCornerWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class LowerRightCornerWall extends WallPattern {
 
     public LowerRightCornerWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerEastWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerEastWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class TCornerEastWall extends WallPattern {
 
     public TCornerEastWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerNorthWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerNorthWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class TCornerNorthWall extends WallPattern {
 
     public TCornerNorthWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerSouthWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerSouthWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class TCornerSouthWall extends WallPattern {
 
     public TCornerSouthWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerWestWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/TCornerWestWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class TCornerWestWall extends WallPattern {
 
     public TCornerWestWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/UpperLeftCornerWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/UpperLeftCornerWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class UpperLeftCornerWall extends WallPattern {
 
     public UpperLeftCornerWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/UpperRightCornerWall.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/dungeonCreator/wallpattern/UpperRightCornerWall.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.DungeonTextures;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.Coordinate;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.tiles.Tile;
+
 public class UpperRightCornerWall extends WallPattern {
 
     public UpperRightCornerWall(ObjectMap<DungeonTextures, Texture> textureMap) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/EntityController.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/EntityController.java
@@ -1,8 +1,8 @@
 package de.fhbielefeld.pmdungeon.vorgaben.game.Controller;
 
 import de.fhbielefeld.pmdungeon.vorgaben.interfaces.IEntity;
+
 import java.util.ArrayList;
-import java.util.function.Predicate;
 
 
 /**
@@ -14,9 +14,11 @@ public class EntityController {
      * Contains all the entities this controller handles.
      */
     private final ArrayList<IEntity> dungeonEntities;
+
     public EntityController() {
         this.dungeonEntities = new ArrayList<>();
     }
+
     /**
      * calls the update method for every entity in the list.
      * removes entity if deletable is set true
@@ -35,6 +37,7 @@ public class EntityController {
         if (!dungeonEntities.contains(entity))
             this.dungeonEntities.add(entity);
     }
+
     /**
      * removes entity from the list
      *
@@ -48,20 +51,23 @@ public class EntityController {
     /**
      * removes all entities from the list
      */
-    public void removeAll(){
+    public void removeAll() {
         this.dungeonEntities.clear();
     }
 
     /**
      * removes all instances of the class c from the list
+     *
      * @param c referenz Class (use Class.forName("PACKAGE.CLASSNAME") )
      */
-    public void removeAllFrom(Class<?> c){
+    public void removeAllFrom(Class<?> c) {
         dungeonEntities.removeIf(obj -> c.isInstance(obj));
     }
 
     /**
      * returns entity list
      */
-    public ArrayList<IEntity> getList(){ return this.dungeonEntities;}
+    public ArrayList<IEntity> getList() {
+        return this.dungeonEntities;
+    }
 }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/LevelController.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/LevelController.java
@@ -118,7 +118,7 @@ public class LevelController {
      * Draws the dungeon itself.
      */
     public void draw() {
-        if(dungeonWorld==null) return;
+        if (dungeonWorld == null) return;
         dungeonWorld.renderFloor(GameSetup.batch);
         dungeonWorld.renderWalls(dungeonWorld.getHeight() - 1, 0, GameSetup.batch);
     }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/LevelController.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/LevelController.java
@@ -118,6 +118,7 @@ public class LevelController {
      * Draws the dungeon itself.
      */
     public void draw() {
+        if(dungeonWorld==null) return;
         dungeonWorld.renderFloor(GameSetup.batch);
         dungeonWorld.renderWalls(dungeonWorld.getHeight() - 1, 0, GameSetup.batch);
     }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/MainController.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/MainController.java
@@ -52,6 +52,8 @@ public class MainController extends ScreenAdapter {
      */
     protected boolean firstFrame = true;
 
+    //if you call a gdx function in setup this will call draw, so this boolean will be used to stop loops of firstFrame
+    private boolean finishedSetup = false;
 
     //----------------------------- OWN IMPLEMENTATION -----------------------------
     protected void setup() {
@@ -72,12 +74,17 @@ public class MainController extends ScreenAdapter {
      * Setup for the MainController
      */
     private void firstFrame() {
-        this.entityController = new EntityController();
-        this.hud = new HUD();
-        this.textHUD = new TextStage(hud.getHudBatch());
-        setupCamera();
-        setupWorldController();
-        setup();
+        if (!finishedSetup) {
+            this.entityController = new EntityController();
+            this.hud = new HUD();
+            this.textHUD = new TextStage(hud.getHudBatch());
+            setupCamera();
+            setupWorldController();
+            finishedSetup = true;
+            setup();
+        }
+
+
         //load first level
         try {
             levelController.loadDungeon(new DungeonConverter().dungeonFromJson(Constants.STARTLEVEL));
@@ -86,8 +93,8 @@ public class MainController extends ScreenAdapter {
         } catch (IllegalAccessException e) {
             e.printStackTrace();
         }
-
         firstFrame = false;
+
     }
 
     /**

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/MainController.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/Controller/MainController.java
@@ -2,21 +2,17 @@ package de.fhbielefeld.pmdungeon.vorgaben.game.Controller;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
-import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.utils.viewport.ExtendViewport;
-import com.badlogic.gdx.utils.viewport.ScalingViewport;
-import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import de.fhbielefeld.pmdungeon.vorgaben.dungeonCreator.dungeonconverter.DungeonConverter;
 import de.fhbielefeld.pmdungeon.vorgaben.game.GameSetup;
+import de.fhbielefeld.pmdungeon.vorgaben.graphic.HUD;
 import de.fhbielefeld.pmdungeon.vorgaben.graphic.TextStage;
 import de.fhbielefeld.pmdungeon.vorgaben.tools.Constants;
 import de.fhbielefeld.pmdungeon.vorgaben.tools.DungeonCamera;
-import de.fhbielefeld.pmdungeon.vorgaben.graphic.HUD;
-
-import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
+import static com.badlogic.gdx.graphics.GL20.GL_COLOR_BUFFER_BIT;
 
 /**
  * Controls the game.

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/GameSetup.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/game/GameSetup.java
@@ -1,8 +1,6 @@
 package de.fhbielefeld.pmdungeon.vorgaben.game;
 
-import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Game;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import de.fhbielefeld.pmdungeon.vorgaben.game.Controller.MainController;
 
@@ -17,8 +15,9 @@ public class GameSetup extends Game {
      */
     public static SpriteBatch batch;
     private final MainController mc;
-    public GameSetup(MainController mc){
-        this.mc=mc;
+
+    public GameSetup(MainController mc) {
+        this.mc = mc;
     }
 
     @Override
@@ -29,7 +28,9 @@ public class GameSetup extends Game {
     }
 
     @Override
-    public void dispose() {batch.dispose();}
+    public void dispose() {
+        batch.dispose();
+    }
 
 
 }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
@@ -31,6 +31,7 @@ public class HUD {
 
     /**
      * Toogle between grid and pixel based system
+     *
      * @param b activate or deactivate pixel system
      */
     public void usePixelSystem(boolean b) {

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
@@ -19,6 +19,7 @@ public class HUD {
     private final SpriteBatch hudBatch;
     private final OrthographicCamera hudCamera;
     private final List<IHUDElement> hudElements;
+    private boolean usePixelSystem=false;
 
     public HUD() {
         hudBatch = new SpriteBatch();
@@ -26,6 +27,10 @@ public class HUD {
         hudCamera.position.set(0, 0, 0);
         hudCamera.update();
         hudElements = new ArrayList<>();
+    }
+
+    public void changeSystem(){
+        this.usePixelSystem=!this.usePixelSystem;
     }
 
     /**
@@ -51,8 +56,10 @@ public class HUD {
      * Main loop of the hud.
      */
     public void draw() {
-        hudCamera.update();
-        hudBatch.setProjectionMatrix(hudCamera.combined);
+        if(!usePixelSystem){
+            hudCamera.update();
+            hudBatch.setProjectionMatrix(hudCamera.combined);
+        }
         drawElements();
         resize();
 
@@ -79,6 +86,7 @@ public class HUD {
      * Resizing the camera according to the size of the window.
      */
     public void resize() {
+        if (usePixelSystem) return;
         hudCamera.setToOrtho(false, Constants.VIRTUALHEIGHT * Constants.WIDTH / (float) Constants.HEIGHT, Constants.VIRTUALHEIGHT);
         hudBatch.setProjectionMatrix(hudCamera.combined);
     }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
@@ -19,7 +19,7 @@ public class HUD {
     private final SpriteBatch hudBatch;
     private final OrthographicCamera hudCamera;
     private final List<IHUDElement> hudElements;
-    private boolean usePixelSystem=false;
+    private boolean usePixelSystem = false;
 
     public HUD() {
         hudBatch = new SpriteBatch();
@@ -32,8 +32,8 @@ public class HUD {
     /**
      * Toogle between grid and pixel based system
      */
-    public void changeSystem(){
-        this.usePixelSystem=!this.usePixelSystem;
+    public void changeSystem() {
+        this.usePixelSystem = !this.usePixelSystem;
     }
 
     /**
@@ -59,7 +59,7 @@ public class HUD {
      * Main loop of the hud.
      */
     public void draw() {
-        if(!usePixelSystem){
+        if (!usePixelSystem) {
             hudCamera.update();
             hudBatch.setProjectionMatrix(hudCamera.combined);
         }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
@@ -29,6 +29,9 @@ public class HUD {
         hudElements = new ArrayList<>();
     }
 
+    /**
+     * Toogle between grid and pixel based system
+     */
     public void changeSystem(){
         this.usePixelSystem=!this.usePixelSystem;
     }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
@@ -17,14 +17,14 @@ import java.util.List;
  */
 public class HUD {
     private final SpriteBatch hudBatch;
-    private final OrthographicCamera hudCamera;
+    //private final OrthographicCamera hudCamera;
     private final List<IHUDElement> hudElements;
 
     public HUD() {
         hudBatch = new SpriteBatch();
-        hudCamera = new OrthographicCamera();
-        hudCamera.position.set(0, 0, 0);
-        hudCamera.update();
+        // hudCamera = new OrthographicCamera();
+       // hudCamera.position.set(0, 0, 0);
+       // hudCamera.update();
         hudElements = new ArrayList<>();
     }
 
@@ -51,8 +51,8 @@ public class HUD {
      * Main loop of the hud.
      */
     public void draw() {
-        hudCamera.update();
-        hudBatch.setProjectionMatrix(hudCamera.combined);
+        //hudCamera.update();
+        //hudBatch.setProjectionMatrix(hudCamera.combined);
         drawElements();
         resize();
 
@@ -79,8 +79,8 @@ public class HUD {
      * Resizing the camera according to the size of the window.
      */
     public void resize() {
-        hudCamera.setToOrtho(false, Constants.VIRTUALHEIGHT * Constants.WIDTH / (float) Constants.HEIGHT, Constants.VIRTUALHEIGHT);
-        hudBatch.setProjectionMatrix(hudCamera.combined);
+        //hudCamera.setToOrtho(false, Constants.VIRTUALHEIGHT * Constants.WIDTH / (float) Constants.HEIGHT, Constants.VIRTUALHEIGHT);
+        //hudBatch.setProjectionMatrix(hudCamera.combined);
     }
 
 

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
@@ -17,14 +17,14 @@ import java.util.List;
  */
 public class HUD {
     private final SpriteBatch hudBatch;
-    //private final OrthographicCamera hudCamera;
+    private final OrthographicCamera hudCamera;
     private final List<IHUDElement> hudElements;
 
     public HUD() {
         hudBatch = new SpriteBatch();
-        // hudCamera = new OrthographicCamera();
-       // hudCamera.position.set(0, 0, 0);
-       // hudCamera.update();
+        hudCamera = new OrthographicCamera();
+        hudCamera.position.set(0, 0, 0);
+        hudCamera.update();
         hudElements = new ArrayList<>();
     }
 
@@ -51,8 +51,8 @@ public class HUD {
      * Main loop of the hud.
      */
     public void draw() {
-        //hudCamera.update();
-        //hudBatch.setProjectionMatrix(hudCamera.combined);
+        hudCamera.update();
+        hudBatch.setProjectionMatrix(hudCamera.combined);
         drawElements();
         resize();
 
@@ -79,8 +79,8 @@ public class HUD {
      * Resizing the camera according to the size of the window.
      */
     public void resize() {
-        //hudCamera.setToOrtho(false, Constants.VIRTUALHEIGHT * Constants.WIDTH / (float) Constants.HEIGHT, Constants.VIRTUALHEIGHT);
-        //hudBatch.setProjectionMatrix(hudCamera.combined);
+        hudCamera.setToOrtho(false, Constants.VIRTUALHEIGHT * Constants.WIDTH / (float) Constants.HEIGHT, Constants.VIRTUALHEIGHT);
+        hudBatch.setProjectionMatrix(hudCamera.combined);
     }
 
 

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/graphic/HUD.java
@@ -31,9 +31,10 @@ public class HUD {
 
     /**
      * Toogle between grid and pixel based system
+     * @param b activate or deactivate pixel system
      */
-    public void changeSystem() {
-        this.usePixelSystem = !this.usePixelSystem;
+    public void usePixelSystem(boolean b) {
+        this.usePixelSystem = b;
     }
 
     /**

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
@@ -8,6 +8,7 @@ import de.fhbielefeld.pmdungeon.vorgaben.interfaces.IDrawable;
  */
 public class DungeonCamera extends OrthographicCamera {
     private IDrawable follows;
+    private Point focusPoint;
 
     /**
      * Creates a new camera.
@@ -18,7 +19,9 @@ public class DungeonCamera extends OrthographicCamera {
      */
     public DungeonCamera(IDrawable follows, float vw, float vh) {
         super(vw, vh);
-        this.follows = follows;
+        if (follows != null)
+            this.follows = follows;
+        else focusPoint = new Point(0, 0)
     }
 
     /**
@@ -38,13 +41,24 @@ public class DungeonCamera extends OrthographicCamera {
     }
 
     /**
+     * Stops following and set the camera on a fix position
+     *
+     * @param focusPoint Point to set the camera on
+     */
+    public void setFocusPoint(Point focusPoint) {
+        this.follows = null;
+        this.focusPoint = focusPoint;
+    }
+
+
+    /**
      * update camera position
      */
     public void update() {
         if (follows != null)
             this.position.set(this.getFollowedObject().getPosition().x, this.getFollowedObject().getPosition().y, 0);
         else
-            this.position.set(0, 0, 0);
+            this.position.set(focusPoint.x, focusPoint.y, 0);
 
         super.update();
     }

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
@@ -9,6 +9,7 @@ import de.fhbielefeld.pmdungeon.vorgaben.interfaces.IDrawable;
 public class DungeonCamera extends OrthographicCamera {
     private IDrawable follows;
     private Point focusPoint;
+    ;
 
     /**
      * Creates a new camera.
@@ -21,7 +22,7 @@ public class DungeonCamera extends OrthographicCamera {
         super(vw, vh);
         if (follows != null)
             this.follows = follows;
-        else focusPoint = new Point(0, 0);
+
     }
 
     /**
@@ -57,9 +58,11 @@ public class DungeonCamera extends OrthographicCamera {
     public void update() {
         if (follows != null)
             this.position.set(this.getFollowedObject().getPosition().x, this.getFollowedObject().getPosition().y, 0);
-        else
-            this.position.set(focusPoint.x, focusPoint.y, 0);
-
+        else {
+            if (this.focusPoint == null)
+                this.focusPoint = new Point(0, 0);
+            this.position.set(this.focusPoint.x, this.focusPoint.y, 0);
+        }
         super.update();
     }
 

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
@@ -9,7 +9,6 @@ import de.fhbielefeld.pmdungeon.vorgaben.interfaces.IDrawable;
 public class DungeonCamera extends OrthographicCamera {
     private IDrawable follows;
     private Point focusPoint;
-    ;
 
     /**
      * Creates a new camera.

--- a/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
+++ b/core/src/de/fhbielefeld/pmdungeon/vorgaben/tools/DungeonCamera.java
@@ -21,7 +21,7 @@ public class DungeonCamera extends OrthographicCamera {
         super(vw, vh);
         if (follows != null)
             this.follows = follows;
-        else focusPoint = new Point(0, 0)
+        else focusPoint = new Point(0, 0);
     }
 
     /**

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "java"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-sourceSets.main.java.srcDirs = [ "src/" ]
+sourceSets.main.java.srcDirs = ["src/"]
 //sourceSets.main.resources.srcDirs = ["../core/assets"]
 
 project.ext.mainClassName = "de.fhbielefeld.pmdungeon.desktop.DesktopLauncher"
@@ -12,7 +12,7 @@ task run(dependsOn: classes, type: JavaExec) {
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
-  //  workingDir = project.assetsDir
+    //  workingDir = project.assetsDir
     ignoreExitValue = true
 }
 

--- a/desktop/src/de/fhbielefeld/pmdungeon/desktop/DesktopLauncher.java
+++ b/desktop/src/de/fhbielefeld/pmdungeon/desktop/DesktopLauncher.java
@@ -1,7 +1,6 @@
 package de.fhbielefeld.pmdungeon.desktop;
 
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import de.fhbielefeld.pmdungeon.vorgaben.game.Controller.MainController;
@@ -12,6 +11,7 @@ public class DesktopLauncher {
 
     /**
      * Runs the dungeon.
+     *
      * @param mc MainController of the Dungeon
      */
     public static void run(MainController mc) {
@@ -19,7 +19,7 @@ public class DesktopLauncher {
 
         config.setTitle(Constants.WINDOWNAME);
         config.setForegroundFPS(Constants.FRAMERATE);
-        config.setWindowedMode(Constants.WIDTH,Constants.HEIGHT);
+        config.setWindowedMode(Constants.WIDTH, Constants.HEIGHT);
         config.setResizable(false);
         new Lwjgl3Application(new GameSetup(mc), config);
     }


### PR DESCRIPTION
*HUD*
- hud can now be toggled between pixel and grid system with `HUD.usePixelSystem(boolean)` (maybe you have to rescale your HUD-Elements for this).


*DungeonCamera*
- dungeon camera do not focus anymore on `(0,0,0)` if no followable object is set. This allows free camera movements. 
- add `DungeonCamera.setFocusPoint(Point)`. Stops following and set the camera on a fix position

*Bug fixes* 
- fixed issue where firstFrame was called twice if you resize the window in `setup`. This would call `setup` again and loads the first level twice. 