### PR TITLE
Maven Build Skript erstellt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,10 @@ gradle-app.setting
 /ios/build/
 /ios-moe/build/
 
+## Maven
+
+*/target/*
+
 ## OS Specific
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ lang: de-DE
 
 Dieses Dokument liefert einen Einstieg in das PM-Dungeon. Es erläutert die Installation der API und erläutert Ihnen die ersten Schritte, um eigene Inhalte zum Dungeon hinzuzufügen. Es dient als Grundlage für alle weiteren Praktika. Lesen Sie das Dokument daher aufmerksam durch und versuchen Sie sich zusätzlich selbst mit dem Aufbau vertraut zu machen.
 
+## Build jar mit Maven
+
+Die erforderliche jar kann einfach über Maven erstellt werden. Hierfür kann der folgende Befehl genutzt werden:
+```bash
+    mvn package
+```
+Die jar mit allen Abhängigkeiten inkludiert liegt nun unter *"desktop/target/pmdungeon-desktop-jar-with-dependencies.jar"* und kann nach belieben umbenannt werden.
+
 ## Installation
 
 - Laden Sie sich das `pmdungeon.jar` und den `assets`-Ordner mit Texturen und Level-Beschreibungen herunter. Das `pmdungeon.jar` wird Ihnen als API dienen.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Unten sehen Sie eine vereinfachte Darstellung wie unser Dungeon jetzt funktionie
 
 ## Head-up-Display (HUD)
 
-Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung. Alternativ können Sie ab Version `1.1.5.0` mithilfe von `hud.usePixelSystem(true)` im `MainCotroller` auf ein pixelbasiertes HUD wechseln. 
+Dieser Abschnitt soll Ihnen die Werkzeuge nahebringen, welche Sie für die Darstellung eines HUD benötigen. Anders als im bereits bekannten Vorgehen, verwendet das HUD Koordinaten im Bereich von `x: 0 bis 6` und `y: 0 bis 5`, dabei stehen Ihnen auch `float`-Werte zur Verfügung. Alternativ können Sie ab Version `1.1.5.0` mithilfe von `hud.usePixelSystem(true)` im `MainController` auf ein pixelbasiertes HUD wechseln.
 
 Um eine Grafik auf dem HUD anzeigen zu können, erstellen wir zuerst eine neue Klasse, welche das Interface `IHUDElement` implementiert.
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,37 +13,40 @@
 
     <properties>
         <jdk.version>14</jdk.version>
+        <gdx.version>1.9.12</gdx.version>
+        <gdxai.version>1.8.1</gdxai.version>
+        <gson.version>2.8.6</gson.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx</artifactId>
-            <version>1.9.12</version>
+            <version>${gdx.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-box2d</artifactId>
-            <version>1.9.12</version>
+            <version>${gdx.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-ai</artifactId>
-            <version>1.8.1</version>
+            <version>${gdxai.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>${gson.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-freetype</artifactId>
-            <version>1.9.12</version>
+            <version>${gdx.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -64,5 +67,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>core</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>de.fhbielefeld</groupId>
+        <artifactId>pmdungeon</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <properties>
+        <jdk.version>14</jdk.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx</artifactId>
+            <version>1.9.12</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-box2d</artifactId>
+            <version>1.9.12</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-ai</artifactId>
+            <version>1.8.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-freetype</artifactId>
+            <version>1.9.12</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>pmdungeon-core</finalName>
+        <sourceDirectory>src</sourceDirectory>
+        <plugins>
+            <!-- Set a JDK compiler level -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <properties>
-        <jdk.version>14</jdk.version>
+        <jdk.version>11</jdk.version>
         <gdx.version>1.9.12</gdx.version>
         <gdxai.version>1.8.1</gdxai.version>
         <gson.version>2.8.6</gson.version>
@@ -33,6 +33,12 @@
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-freetype</artifactId>
+            <version>${gdx.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-ai</artifactId>
             <version>${gdxai.version}</version>
             <scope>compile</scope>
@@ -41,12 +47,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.badlogicgames.gdx</groupId>
-            <artifactId>gdx-freetype</artifactId>
-            <version>${gdx.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,13 +11,6 @@
         <version>1.0</version>
     </parent>
 
-    <properties>
-        <jdk.version>11</jdk.version>
-        <gdx.version>1.9.12</gdx.version>
-        <gdxai.version>1.8.1</gdxai.version>
-        <gson.version>2.8.6</gson.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
@@ -55,15 +48,9 @@
         <finalName>pmdungeon-core</finalName>
         <sourceDirectory>src</sourceDirectory>
         <plugins>
-            <!-- Set a JDK compiler level -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -11,12 +11,6 @@
         <version>1.0</version>
     </parent>
 
-    <properties>
-        <jdk.version>11</jdk.version>
-        <gdx.version>1.9.12</gdx.version>
-        <pmd-core.version>1.0</pmd-core.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
@@ -57,35 +51,13 @@
         <finalName>pmdungeon-desktop</finalName>
         <sourceDirectory>src</sourceDirectory>
         <plugins>
-            <!-- Set a JDK compiler level -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
             </plugin>
-            <!-- Creates an independend jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -12,10 +12,8 @@
     </parent>
 
     <properties>
-        <jdk.version>14</jdk.version>
+        <jdk.version>11</jdk.version>
         <gdx.version>1.9.12</gdx.version>
-        <gdxai.version>1.8.1</gdxai.version>
-        <gson.version>2.8.6</gson.version>
         <pmd-core.version>1.0</pmd-core.version>
     </properties>
 
@@ -41,16 +39,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>de.fhbielefeld</groupId>
-            <artifactId>core</artifactId>
-            <version>${pmd-core.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-freetype-platform</artifactId>
             <version>${gdx.version}</version>
             <classifier>natives-desktop</classifier>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.fhbielefeld</groupId>
+            <artifactId>core</artifactId>
+            <version>${pmd-core.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>desktop</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>de.fhbielefeld</groupId>
+        <artifactId>pmdungeon</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <properties>
+        <jdk.version>14</jdk.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-backend-lwjgl3</artifactId>
+            <version>1.9.12</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-platform</artifactId>
+            <version>1.9.12</version>
+            <classifier>natives-desktop</classifier>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-box2d-platform</artifactId>
+            <version>1.9.12</version>
+            <classifier>natives-desktop</classifier>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.fhbielefeld</groupId>
+            <artifactId>core</artifactId>
+            <version>1.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-freetype-platform</artifactId>
+            <version>1.9.12</version>
+            <classifier>natives-desktop</classifier>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>pmdungeon-desktop</finalName>
+        <sourceDirectory>src</sourceDirectory>
+        <plugins>
+            <!-- Set a JDK compiler level -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                </configuration>
+            </plugin>
+
+            <!-- Creates an independend jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -13,39 +13,43 @@
 
     <properties>
         <jdk.version>14</jdk.version>
+        <gdx.version>1.9.12</gdx.version>
+        <gdxai.version>1.8.1</gdxai.version>
+        <gson.version>2.8.6</gson.version>
+        <pmd-core.version>1.0</pmd-core.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-backend-lwjgl3</artifactId>
-            <version>1.9.12</version>
+            <version>${gdx.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-platform</artifactId>
-            <version>1.9.12</version>
+            <version>${gdx.version}</version>
             <classifier>natives-desktop</classifier>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-box2d-platform</artifactId>
-            <version>1.9.12</version>
+            <version>${gdx.version}</version>
             <classifier>natives-desktop</classifier>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.fhbielefeld</groupId>
             <artifactId>core</artifactId>
-            <version>1.0</version>
+            <version>${pmd-core.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.badlogicgames.gdx</groupId>
             <artifactId>gdx-freetype-platform</artifactId>
-            <version>1.9.12</version>
+            <version>${gdx.version}</version>
             <classifier>natives-desktop</classifier>
             <scope>compile</scope>
         </dependency>
@@ -65,13 +69,11 @@
                     <target>${jdk.version}</target>
                 </configuration>
             </plugin>
-
             <!-- Creates an independend jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.3.0</version>
-
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -87,8 +89,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>de.fhbielefeld</groupId>
+    <artifactId>pmdungeon</artifactId>
+    <version>1.0</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>core</module>
+        <module>desktop</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,4 +11,55 @@
         <module>core</module>
         <module>desktop</module>
     </modules>
+
+    <properties>
+        <pmd-core.version>1.0</pmd-core.version>
+
+        <!-- Defines the dependency versions. -->
+        <jdk.version>11</jdk.version>
+        <gdx.version>1.9.12</gdx.version>
+        <gdxai.version>1.8.1</gdxai.version>
+        <gson.version>2.8.6</gson.version>
+
+        <!-- Defines the maven plugin versions. -->
+        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <assembly-plugin.version>3.3.0</assembly-plugin.version>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Set a JDK compiler level -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                    <configuration>
+                        <source>${jdk.version}</source>
+                        <target>${jdk.version}</target>
+                    </configuration>
+                </plugin>
+                <!-- Creates an independend jar -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${assembly-plugin.version}</version>
+                    <configuration>
+                        <descriptorRefs>
+                            <descriptorRef>jar-with-dependencies</descriptorRef>
+                        </descriptorRefs>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>make-assembly</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
Wir haben die Build Skripte für Maven erstellt.
Diese bieten zudem die Funktion mit dem Target package direkt eine .jar mit allen Abhängigkeiten zu erstellen.
Die Gradle Unterstützung haben wir zur Kompatibilität noch im Projekt gelassen.

Man könnte zusätzlich noch ein Target anlegen, um die Artefakte direkt in das Maven Central Repository zu veröffentlichen, allerdings müsste man dann noch wegen Lizenzen und anderer Kleinigkeiten schauen.
Eine Übersicht zu den Anforderung kann man hier finden:
https://central.sonatype.org/publish/requirements/

---

fixes #41, in conflict w/ #38