### PR TITLE
Target: Create jar, Version control for all build scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,9 @@ mainClassName = "de.pmdungeon.desktop.Main"
 version = "1.0"
 ext {
     appName = "pmdungeon"
-    gdxVersion = "1.10.0"
-    aiVersion = "1.8.2"
-    gsonVersion = "2.8.6"
 }
+def props = new Properties()
+file("build.properties").withInputStream { props.load(it) }
 
 repositories {
     mavenLocal()
@@ -24,16 +23,16 @@ repositories {
 }
 
 dependencies {
-    api "com.google.code.gson:gson:$gsonVersion"
-    api "com.badlogicgames.gdx:gdx-ai:$aiVersion"
-    api "com.badlogicgames.gdx:gdx:$gdxVersion"
-    api "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
-    api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
-    api "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
-    api "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
-    api "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
-    api "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
-    api "com.badlogicgames.gdx:gdx-tools:$gdxVersion"
+    api "com.google.code.gson:gson:"+props.getProperty("gsonVersion")
+    api "com.badlogicgames.gdx:gdx-ai:"+props.getProperty("gdxAiVersion")
+    api "com.badlogicgames.gdx:gdx:"+props.getProperty("gdxVersion")
+    api "com.badlogicgames.gdx:gdx-backend-lwjgl3:"+props.getProperty("gdxVersion")
+    api "com.badlogicgames.gdx:gdx-platform:"+props.getProperty("gdxVersion")+":natives-desktop"
+    api "com.badlogicgames.gdx:gdx-box2d:"+props.getProperty("gdxVersion")
+    api "com.badlogicgames.gdx:gdx-box2d-platform:"+props.getProperty("gdxVersion")+":natives-desktop"
+    api "com.badlogicgames.gdx:gdx-freetype:"+props.getProperty("gdxVersion")
+    api "com.badlogicgames.gdx:gdx-freetype-platform:"+props.getProperty("gdxVersion")+":natives-desktop"
+    api "org.lwjgl:lwjgl:"+props.getProperty("lwjglVersion")
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ sourceCompatibility = 1.11
 sourceSets.main.java.srcDirs = ["src"]
 mainClassName = "de.pmdungeon.desktop.Main"
 
-version = "1.0"
 ext {
     appName = "pmdungeon"
 }
@@ -40,4 +39,5 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    destinationDirectory.set(file("target"))
 }

--- a/build.xml
+++ b/build.xml
@@ -54,6 +54,7 @@
             <fileset dir="${classes.dir}" includes="*.class" />
             <zipgroupfileset dir="${lib.dir}" includes="*.jar" />
             <manifest>
+                <attribute name="Main-Class" value="${main-class}" />
             </manifest>
         </jar>
     </target>

--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
     <property name="build.dir" value="build" />
     <property name="lib.dir" value="lib" />
     <property name="classes.dir" value="${build.dir}/classes" />
-    <property name="jar.dir" value="${build.dir}/jar" />
+    <property name="jar.dir" value="target" />
 
     <property name="ivy.install.version" value="${ivyVersion}" />
     <condition property="ivy.home" value="${env.IVY_HOME}">

--- a/build.xml
+++ b/build.xml
@@ -16,6 +16,9 @@
 
     <property name="main-class" value="de.pmdungeon.desktop.Main" />
 
+    <property name="javac.source" value="11" />
+    <property name="javac.target" value="11" />
+
     <path id="src.path">
         <pathelement location="src" />
     </path>
@@ -23,7 +26,6 @@
         <pathelement path="${classes.dir}" />
         <fileset dir="${lib.dir}" includes="**/*.jar" />
     </path>
-
 
     <target name="clean" description="target to clean the build directory">
         <delete dir="${build.dir}" />
@@ -36,7 +38,7 @@
 
     <target name="compile" depends="resolve" description="target to resolve all dependencies and to compile all sources">
         <mkdir dir="${classes.dir}" />
-        <javac includeantruntime="false" destdir="${classes.dir}" classpathref="classpath" debug="true">
+        <javac includeantruntime="false" destdir="${classes.dir}" classpathref="classpath" source="${javac.source}" target="${javac.target}" debug="true">
             <src refid="src.path" />
         </javac>
     </target>
@@ -52,7 +54,6 @@
             <fileset dir="${classes.dir}" includes="*.class" />
             <zipgroupfileset dir="${lib.dir}" includes="*.jar" />
             <manifest>
-                <attribute name="Main-Class" value="${main-class}" />
             </manifest>
         </jar>
     </target>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <gson.version>2.8.6</gson.version>
         <gdxai.version>1.8.1</gdxai.version>
         <gdx.version>1.9.12</gdx.version>
+        <lwjgl.version>3.2.3</lwjgl.version>
     </properties>
 
     <dependencies>
@@ -76,6 +77,13 @@
             <classifier>natives-desktop</classifier>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <version>${lwjgl.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -97,6 +105,7 @@
                     <configuration>
                         <archive>
                             <manifest>
+                                <mainClass>de.pmdungeon.desktop.Main</mainClass>
                             </manifest>
                         </archive>
                         <descriptorRefs>

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,7 @@
     <version>1.0</version>
 
     <properties>
-        <pmd-core.version>1.0</pmd-core.version>
-
-        <!-- Defines the dependency versions. -->
-        <jdk.version>11</jdk.version>
+        <java.version>11</java.version>
 
         <gson.version>2.8.6</gson.version>
         <gdxai.version>1.8.1</gdxai.version>
@@ -90,9 +87,31 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>${jdk.version}</source>
-                        <target>${jdk.version}</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                            </manifest>
+                        </archive>
+                        <descriptorRefs>
+                            <descriptorRef>jar-with-dependencies</descriptorRef>
+                        </descriptorRefs>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>make-assembly</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
             <groupId>org.lwjgl</groupId>
             <artifactId>lwjgl</artifactId>
             <version>${lwjgl.version}</version>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>
@@ -111,6 +112,8 @@
                         <descriptorRefs>
                             <descriptorRef>jar-with-dependencies</descriptorRef>
                         </descriptorRefs>
+                        <finalName>pmdungeon</finalName>
+                        <appendAssemblyId>false</appendAssemblyId>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
resolves #9 , resolves #69 

Run: `gradlew jar` -> `build/libs/pmdungeon-1.0.jar`
or
run: `ant jar` -> `build/jar/pmdungeon.jar`
or
run: `mvn clean compile assembly:single` -> `target/pmdungeon-1.0-jar-with-dependencies.jar`

Properties for Gradle and Ant are in the `build.properties` file.
Properties for Maven/`pom.xml` aren't possible. 🙁 

Btw. i fixed some Gradle dependencies...